### PR TITLE
Fix Timelog API call

### DIFF
--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -172,7 +172,7 @@ const api = {
             keys.workOrderTimeLogs.sceneId
           }/views/${
             keys.workOrderTimeLogs.viewId
-          }/records?my-work-order-details2_id=${id}`,
+          }/records?my-work-order-details_id=${id}`,
           getHeaders()
         ),
       newTimeLog: (id, data) =>


### PR DESCRIPTION
Before, no data was coming back for timelogs on the work orders detail page.

There was a very slight change to the api query parameters, probably effects inventory and images as well, we'll get back to those later.

## Before
![Screen Shot 2019-06-13 at 12 40 24 AM](https://user-images.githubusercontent.com/5697474/59406565-441d3b80-8d74-11e9-9910-20c10ed1e34d.png)

## After

![Screen Shot 2019-06-13 at 12 38 48 AM](https://user-images.githubusercontent.com/5697474/59406575-4a131c80-8d74-11e9-9739-f9bd19a1b9ca.png)

