### PR TITLE
Move New Image and New Time Log buttons into accordion

### DIFF
--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -102,28 +102,6 @@ class WorkOrderDetail extends Component {
             </Link>
           </div>
           <div className="mr-2 mb-2">
-            <Link
-              to={`/work-order/new-time-log/${
-                this.props.match.params.workOrderId
-              }`}
-            >
-              <div className={'btn btn-secondary'}>
-                <FontAwesomeIcon icon={faClock} /> New Time Log
-              </div>
-            </Link>
-          </div>
-          <div className="mr-2 mb-2">
-            <Link
-              to={`/work-order/add-image/${
-                this.props.match.params.workOrderId
-              }`}
-            >
-              <div className={'btn btn-secondary'}>
-                <FontAwesomeIcon icon={faCamera} /> New Image
-              </div>
-            </Link>
-          </div>
-          <div className="mr-2 mb-2">
             {this.state.timeLogData.length > 0 ? (
               <Link
                 to={`/work-order/submit/${this.props.match.params.workOrderId}`}
@@ -188,6 +166,17 @@ class WorkOrderDetail extends Component {
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
+              <div className="mr-2 mb-2">
+                <Link
+                  to={`/work-order/new-time-log/${
+                    this.props.match.params.workOrderId
+                  }`}
+                >
+                  <div className={'btn btn-secondary'}>
+                    <FontAwesomeIcon icon={faClock} /> New Time Log
+                  </div>
+                </Link>
+              </div>
               <TimeLog data={this.state.timeLogData} />
             </AccordionItemBody>
           </AccordionItem>
@@ -252,6 +241,17 @@ class WorkOrderDetail extends Component {
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
+              <div className="mr-2 mb-2">
+                <Link
+                  to={`/work-order/add-image/${
+                    this.props.match.params.workOrderId
+                  }`}
+                >
+                  <div className={'btn btn-secondary'}>
+                    <FontAwesomeIcon icon={faCamera} /> New Image
+                  </div>
+                </Link>
+              </div>
               {this.state.imagesData.length === 0 && <p>No data</p>}
               {this.state.imagesData.length > 0 && (
                 <ul className="list-group list-group-flush">


### PR DESCRIPTION
Closes #124 

This branch moves the New Image and New Time Log buttons in the Work Order Details page from the button row under the title into the accordion sections for each feature.

![Screen Shot 2019-07-22 at 1 01 07 PM](https://user-images.githubusercontent.com/37249039/61654089-4af77200-ac81-11e9-9073-6fea90f8225d.png)

![Screen Shot 2019-07-22 at 1 01 14 PM](https://user-images.githubusercontent.com/37249039/61653946-0a97f400-ac81-11e9-9626-9e9ae6b23262.png)

