### PR TITLE
77 Add search to My Work Orders page

### DIFF
--- a/src/components/AllWorkOrders.js
+++ b/src/components/AllWorkOrders.js
@@ -1,199 +1,47 @@
 import React, { Component } from "react";
-import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faTruck,
-  faMapMarkerAlt,
-  faSpinner,
-} from "@fortawesome/free-solid-svg-icons";
+import { faTruck } from "@fortawesome/free-solid-svg-icons";
 
-import api from "../queries/api";
+import ListWithSearchAndPage from "./Shared/ListWithSearchAndPages";
+
 import { workOrderFields } from "../queries/fields";
-import { signalsWorkOrderStatuses } from "../constants/statuses";
+import { getAllWorkOrders, searchAllWorkOrders } from "./WorkOrder/helpers";
 
 const fields = workOrderFields.baseFields;
-const statuses = signalsWorkOrderStatuses;
 
 class AllWorkOrders extends Component {
   constructor(props) {
     super(props);
     this.state = {
       allWorkOrdersData: [],
-      loading: false,
-      location: "",
-      currentPage: 1,
+      loading: true,
       lastPage: 1,
     };
   }
 
   componentDidMount() {
-    this.setState({ loading: true });
-    api
-      .allWorkOrders()
-      .getAll()
-      .then(res => {
-        this.setState({
-          allWorkOrdersData: res.data.records,
-          lastPage: res.data.total_pages,
-          loading: false,
-        });
+    getAllWorkOrders().then(data => {
+      this.setState({
+        allWorkOrdersData: data.records,
+        lastPage: data.total_pages,
+        loading: false,
       });
+    });
   }
 
-  handleChange = event => {
-    this.setState({
-      location: event.target.value,
-    });
-  };
-
-  handleSearch = event => {
-    event.preventDefault();
-    this.setState({ allWorkOrdersData: [], loading: true });
-    api
-      .allWorkOrders()
-      .searchAll(this.state.location, 1)
-      .then(res => {
-        this.setState({
-          allWorkOrdersData: res.data.records,
-          loading: false,
-          lastPage: res.data.total_pages,
-          currentPage: 1,
-        });
-      });
-  };
-
-  updatePage = pageNumber => {
-    this.setState({
-      allWorkOrdersData: [],
-      loading: true,
-      currentPage: pageNumber,
-    });
-    api
-      .allWorkOrders()
-      .searchAll(this.state.location, pageNumber)
-      .then(res => {
-        this.setState({
-          allWorkOrdersData: res.data.records,
-          lastPage: res.data.total_pages,
-          loading: false,
-        });
-      });
-    window.scrollTo(0, 0);
-  };
-
-  prevPage = event => {
-    event.preventDefault();
-    // if currentPage !== 1, API call for prev page
-    if (this.state.currentPage !== 1) {
-      const prevPage = this.state.currentPage - 1;
-      this.updatePage(prevPage);
-    }
-  };
-
-  nextPage = event => {
-    event.preventDefault();
-    // if currentPage === lastPage, nothing, else API call for next page
-    if (this.state.currentPage !== this.state.lastPage) {
-      const nextPage = this.state.currentPage + 1;
-      this.updatePage(nextPage);
-    }
-  };
-
   render() {
-    // make sure the data is not an empty object `{}`
-    const isJobsDataLoaded = this.state.allWorkOrdersData.length > 0;
-    const allWorkOrdersData = isJobsDataLoaded
-      ? this.state.allWorkOrdersData
-      : [];
     return (
       <div>
         <h1>
           <FontAwesomeIcon icon={faTruck} /> All Work Orders
         </h1>
-        <form onSubmit={this.handleSearch}>
-          <div className="form-group row">
-            <div className="col">
-              <input
-                type="text"
-                className="form-control"
-                placeholder="Enter search here"
-                value={this.state.location}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="col">
-              <input
-                type="submit"
-                value="Search"
-                className="btn btn-primary btn-lg"
-              />
-            </div>
-          </div>
-        </form>
-        {this.state.loading ? (
-          <FontAwesomeIcon icon={faSpinner} size="2x" className="atd-spinner" />
-        ) : (
-          ""
-        )}
-        <ul className="list-group list-group-flush">
-          {isJobsDataLoaded &&
-            allWorkOrdersData.map(item => (
-              <Link to={`/work-orders/${item.id}`} key={item.id}>
-                <li
-                  className="list-group-item d-flex row"
-                  style={{
-                    backgroundColor:
-                      statuses[item[fields.status]].backgroundColor,
-                    color: statuses[item[fields.status]].textColor,
-                  }}
-                >
-                  {/* Location */}
-                  <div className="col-12">
-                    <FontAwesomeIcon icon={faMapMarkerAlt} />{" "}
-                    <span>{item[fields.locationAll]}</span>
-                  </div>
-                  {/* Status */}
-                  <div className="col-6">
-                    <FontAwesomeIcon
-                      icon={
-                        item[fields.status] &&
-                        statuses[item[fields.status]].icon
-                      }
-                    />
-                    <span> {item[fields.status]}</span>
-                  </div>
-                  {/* Modified at Datetime */}
-                  <div className="col-6">
-                    <span>{item[fields.modified]}</span>
-                  </div>
-                </li>
-              </Link>
-            ))}
-        </ul>
-        <form>
-          <br />
-          <div className="form-group row justify-content-center">
-            <div className="col-auto">
-              <button
-                className="btn btn-primary btn-lg"
-                onClick={this.prevPage}
-              >
-                Prev. Page
-              </button>
-            </div>
-            <div className="col-auto">
-              Page {this.state.currentPage} of {this.state.lastPage}
-            </div>
-            <div className="col-auto">
-              <button
-                className="btn btn-primary btn-lg"
-                onClick={this.nextPage}
-              >
-                Next Page
-              </button>
-            </div>
-          </div>
-        </form>
+
+        <ListWithSearchAndPage
+          data={this.state.allWorkOrdersData}
+          lastPage={this.state.lastPage}
+          searchQuery={searchAllWorkOrders}
+          titleField={fields.locationAll}
+        />
       </div>
     );
   }

--- a/src/components/MyWorkOrders.js
+++ b/src/components/MyWorkOrders.js
@@ -1,114 +1,48 @@
 import React, { Component } from "react";
-import Button from "./Form/Button";
-import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faMapMarkerAlt,
-  faStreetView,
-  faSpinner,
-  faPlus,
-} from "@fortawesome/free-solid-svg-icons";
+import { faStreetView } from "@fortawesome/free-solid-svg-icons";
 
-import api from "../queries/api";
+import ListWithSearchAndPage from "./Shared/ListWithSearchAndPages";
+
 import { workOrderFields } from "../queries/fields";
-import { signalsWorkOrderStatuses } from "../constants/statuses";
+import { getMyWorkOrders, searchMyWorkOrders } from "./WorkOrder/helpers";
 
 const fields = workOrderFields.baseFields;
-const statuses = signalsWorkOrderStatuses;
 
 class MyWorkOrders extends Component {
   constructor(props) {
     super(props);
     this.state = {
       myWorkOrdersData: [],
-      loading: false,
+      loading: true,
+      lastPage: 1,
     };
   }
   componentDidMount() {
-    this.setState({ loading: true });
-    api
-      .myWorkOrders()
-      .getAll()
-      .then(res => {
-        this.setState({ myWorkOrdersData: res.data.records, loading: false });
+    getMyWorkOrders().then(data => {
+      this.setState({
+        myWorkOrdersData: data.records,
+        lastPage: data.total_pages,
+        loading: false,
       });
+    });
   }
 
   render() {
-    // make sure the data is not an empty object `{}`
-    const isMyJobsDataLoaded = this.state.myWorkOrdersData.length > 0;
-    const myWorkOrdersData = isMyJobsDataLoaded
-      ? this.state.myWorkOrdersData
-      : [];
-    if (this.state.myWorkOrderData !== []) {
-      return (
-        <div>
-          <h1>
-            <FontAwesomeIcon icon={faStreetView} /> My Work Orders
-          </h1>
-          <div className="d-flex flex-row">
-            <Button
-              icon={faPlus}
-              text={"New Work Order"}
-              linkPath={"/work-order/new/"}
-            />
-          </div>
-          {this.state.loading ? (
-            <FontAwesomeIcon
-              icon={faSpinner}
-              size="2x"
-              className="atd-spinner"
-            />
-          ) : (
-            ""
-          )}
-          <ul className="list-group list-group-flush">
-            {isMyJobsDataLoaded &&
-              myWorkOrdersData.map(item => (
-                <Link to={`/work-orders/${item.id}`} key={item.id}>
-                  <li
-                    className="list-group-item d-flex row"
-                    style={{
-                      backgroundColor:
-                        statuses[item[fields.status]].backgroundColor,
-                      color: statuses[item[fields.status]].textColor,
-                    }}
-                  >
-                    {/* Location */}
-                    <div className="col-12">
-                      <FontAwesomeIcon icon={faMapMarkerAlt} />{" "}
-                      <span>{item[fields.location]}</span>
-                    </div>
-                    {/* Status */}
-                    <div className="col-6">
-                      <FontAwesomeIcon
-                        icon={
-                          item[fields.status] &&
-                          statuses[item[fields.status]].icon
-                        }
-                      />
-                      <span> {item[fields.status]}</span>
-                    </div>
-                    {/* Modified at Datetime */}
-                    <div className="col-6">
-                      <span>{item[fields.modified]}</span>
-                    </div>
-                  </li>
-                </Link>
-              ))}
-          </ul>
-        </div>
-      );
-    } else {
-      return (
-        <div>
-          <h1>
-            <FontAwesomeIcon icon={faStreetView} /> My Work Orders
-          </h1>
-          <p>You do not have any work orders.</p>
-        </div>
-      );
-    }
+    return (
+      <div>
+        <h1>
+          <FontAwesomeIcon icon={faStreetView} /> My Work Orders
+        </h1>
+
+        <ListWithSearchAndPage
+          data={this.state.myWorkOrdersData}
+          lastPage={this.state.lastPage}
+          searchQuery={searchMyWorkOrders}
+          titleField={fields.location}
+        />
+      </div>
+    );
   }
 }
 

--- a/src/components/Shared/ListWithSearchAndPages.js
+++ b/src/components/Shared/ListWithSearchAndPages.js
@@ -1,0 +1,181 @@
+import React, { Component } from "react";
+import { Link } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMapMarkerAlt, faSpinner } from "@fortawesome/free-solid-svg-icons";
+
+import { workOrderFields } from "../../queries/fields";
+import { signalsWorkOrderStatuses } from "../../constants/statuses";
+
+const fields = workOrderFields.baseFields;
+const statuses = signalsWorkOrderStatuses;
+
+class ListWithSearchAndPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      knackData: [],
+      loading: true,
+      location: "",
+      currentPage: 1,
+      lastPage: 1,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props !== nextProps) {
+      this.setState({
+        knackData: nextProps.data,
+        lastPage: nextProps.lastPage,
+        loading: nextProps.loading,
+      });
+    }
+  }
+
+  handleChange = event => {
+    this.setState({ location: event.target.value });
+  };
+
+  handleSearch = event => {
+    event.preventDefault();
+    this.setState({ knackData: [], loading: true });
+    this.props.searchQuery(this.state.location, 1).then(data => {
+      this.setState({
+        knackData: data.records,
+        loading: false,
+        lastPage: data.total_pages,
+        currentPage: 1,
+      });
+    });
+  };
+
+  updatePage = pageNumber => {
+    this.setState({
+      knackData: [],
+      loading: true,
+      currentPage: pageNumber,
+    });
+
+    this.props.searchQuery(this.state.location, pageNumber).then(data => {
+      this.setState({
+        knackData: data.records,
+        lastPage: data.total_pages,
+        loading: false,
+      });
+    });
+
+    window.scrollTo(0, 0);
+  };
+
+  prevPage = event => {
+    event.preventDefault();
+    // if currentPage !== 1, API call for prev page
+    if (this.state.currentPage !== 1) {
+      const prevPage = this.state.currentPage - 1;
+      this.updatePage(prevPage);
+    }
+  };
+
+  nextPage = event => {
+    event.preventDefault();
+    // if currentPage === lastPage, nothing, else API call for next page
+    if (this.state.currentPage !== this.state.lastPage) {
+      const nextPage = this.state.currentPage + 1;
+      this.updatePage(nextPage);
+    }
+  };
+
+  render() {
+    // make sure the data is not an empty object `{}`
+    const isDataLoaded = this.state.knackData.length > 0;
+    const knackData = isDataLoaded ? this.state.knackData : [];
+
+    return (
+      <div>
+        <form onSubmit={this.handleSearch.bind(this)}>
+          <div className="form-group row">
+            <div className="col">
+              <input
+                type="text"
+                className="form-control"
+                placeholder="Enter search here"
+                value={this.state.location}
+                onChange={this.handleChange}
+              />
+            </div>
+            <div className="col">
+              <input
+                type="submit"
+                value="Search"
+                className="btn btn-primary btn-lg"
+              />
+            </div>
+          </div>
+        </form>
+        {this.state.loading && (
+          <FontAwesomeIcon icon={faSpinner} size="2x" className="atd-spinner" />
+        )}
+        <ul className="list-group list-group-flush">
+          {isDataLoaded &&
+            knackData.map(item => (
+              <Link to={`/work-orders/${item.id}`} key={item.id}>
+                <li
+                  className="list-group-item d-flex row"
+                  style={{
+                    backgroundColor:
+                      statuses[item[fields.status]].backgroundColor,
+                    color: statuses[item[fields.status]].textColor,
+                  }}
+                >
+                  {/* Location */}
+                  <div className="col-12">
+                    <FontAwesomeIcon icon={faMapMarkerAlt} />{" "}
+                    <span>{item[this.props.titleField]}</span>
+                  </div>
+                  {/* Status */}
+                  <div className="col-6">
+                    <FontAwesomeIcon
+                      icon={
+                        item[fields.status] &&
+                        statuses[item[fields.status]].icon
+                      }
+                    />
+                    <span> {item[fields.status]}</span>
+                  </div>
+                  {/* Modified at Datetime */}
+                  <div className="col-6">
+                    <span>{item[fields.modified]}</span>
+                  </div>
+                </li>
+              </Link>
+            ))}
+        </ul>
+        <form>
+          <br />
+          <div className="form-group row justify-content-center">
+            <div className="col-auto">
+              <button
+                className="btn btn-primary btn-lg"
+                onClick={this.prevPage}
+              >
+                Prev. Page
+              </button>
+            </div>
+            <div className="col-auto">
+              Page {this.state.currentPage} of {this.state.lastPage}
+            </div>
+            <div className="col-auto">
+              <button
+                className="btn btn-primary btn-lg"
+                onClick={this.nextPage}
+              >
+                Next Page
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default ListWithSearchAndPage;

--- a/src/components/WorkOrder/helpers.js
+++ b/src/components/WorkOrder/helpers.js
@@ -125,3 +125,31 @@ export async function getAllAssets() {
     sensorOptions,
   };
 }
+
+export function getMyWorkOrders() {
+  return api
+    .myWorkOrders()
+    .getAll()
+    .then(res => res.data);
+}
+
+export function searchMyWorkOrders(searchValue, pageNumber) {
+  return api
+    .myWorkOrders()
+    .search(searchValue, pageNumber)
+    .then(res => res.data);
+}
+
+export function getAllWorkOrders() {
+  return api
+    .allWorkOrders()
+    .getAll()
+    .then(res => res.data);
+}
+
+export function searchAllWorkOrders(searchValue, pageNumber) {
+  return api
+    .allWorkOrders()
+    .searchAll(searchValue, pageNumber)
+    .then(res => res.data);
+}

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -88,6 +88,11 @@ const api = {
           `https://us-api.knack.com/v1/scenes/${keys.allMyWorkOrders.sceneId}/views/${keys.allMyWorkOrders.viewId}/records/`,
           getHeaders()
         ),
+      search: (searchValue, pageNumber) =>
+        axios.get(
+          `https://us-api.knack.com/v1/scenes/${keys.allMyWorkOrders.sceneId}/views/${keys.allMyWorkOrders.viewId}/records?rows_per_page=100&page=${pageNumber}&filters=[{"value":"${searchValue}","operator":"contains","field":"field_904"}]`,
+          getHeaders()
+        ),
     };
   },
   allWorkOrders() {


### PR DESCRIPTION
In this PR I've added search to the `/my-work-orders` page by using the same pattern @mddilley started with the `/all-work-orders` page. 

I've created a new `<ListWithSearchAndPages/>` component that takes these props: 
- `data`: Knack data returned from the componentDidMount API call
- `lastPage`: similar to above
- `searchQuery`: a API helper function for search that differs for AllWorkOrders and MyWorkOrders
- `titleFieldId`: a reference to a field ID which happens to be different for each page too.

_One part of #77_