### PR TITLE
HTML populates from Knack in Problem Found/Action Taken text fields

### DIFF
--- a/src/components/Assets/helpers.js
+++ b/src/components/Assets/helpers.js
@@ -11,7 +11,8 @@ import {
   faCheckSquare,
 } from "@fortawesome/free-solid-svg-icons";
 
-const removeBreakTagsFromString = string => string.replace(/(<br \/>)/gm, " ");
+export const removeBreakTagsFromString = string =>
+  string.replace(/(<br \/>)/gm, "\n");
 
 const isStringAnchorTag = string => {
   try {

--- a/src/components/WorkOrder/WorkSpecifications.js
+++ b/src/components/WorkOrder/WorkSpecifications.js
@@ -3,6 +3,7 @@ import AsyncSelect from "react-select/lib/Async";
 import { FIELDS } from "./formConfig";
 import SubmitButton from "../Form/SubmitButton";
 import { ErrorMessage, SuccessMessage } from "./Alerts";
+import { removeBreakTagsFromString } from "../Assets/helpers";
 
 import api from "../../queries/api";
 
@@ -128,13 +129,19 @@ export default class WorkSpecifications extends Component {
       .workOrder()
       .getTaskOrder(this.props.workOrderId)
       .then(res => {
+        const problemFoundWithoutBreakTags = removeBreakTagsFromString(
+          res.data[FIELDS.WORK_SPECIFICATIONS.PROBLEM_FOUND]
+        );
+        const actionTakenWithoutBreakTags = removeBreakTagsFromString(
+          res.data[FIELDS.WORK_SPECIFICATIONS.ACTION_TAKEN]
+        );
         const updatedFormData = {
-          [FIELDS.WORK_SPECIFICATIONS.PROBLEM_FOUND]:
-            res.data[FIELDS.WORK_SPECIFICATIONS.PROBLEM_FOUND],
+          [FIELDS.WORK_SPECIFICATIONS
+            .PROBLEM_FOUND]: problemFoundWithoutBreakTags,
           [FIELDS.WORK_SPECIFICATIONS.TASK_ORDERS]:
             res.data[`${FIELDS.WORK_SPECIFICATIONS.TASK_ORDERS}_raw`],
-          [FIELDS.WORK_SPECIFICATIONS.ACTION_TAKEN]:
-            res.data[FIELDS.WORK_SPECIFICATIONS.ACTION_TAKEN],
+          [FIELDS.WORK_SPECIFICATIONS
+            .ACTION_TAKEN]: actionTakenWithoutBreakTags,
           [FIELDS.WORK_SPECIFICATIONS.CHECKED_ALL]:
             res.data[FIELDS.WORK_SPECIFICATIONS.CHECKED_ALL],
           [FIELDS.WORK_SPECIFICATIONS.FOLLOW_UP_NEEDED]:
@@ -244,7 +251,7 @@ export default class WorkSpecifications extends Component {
                       FIELDS.WORK_SPECIFICATIONS.PROBLEM_FOUND
                     ]
                   }
-                ></textarea>
+                />
               </div>
               <div className="form-group">
                 <label
@@ -281,7 +288,7 @@ export default class WorkSpecifications extends Component {
                       FIELDS.WORK_SPECIFICATIONS.ACTION_TAKEN
                     ]
                   }
-                ></textarea>
+                />
               </div>
               <div className="form-group">
                 <label htmlFor={FIELDS.WORK_SPECIFICATIONS.CHECKED_ALL}>
@@ -378,7 +385,7 @@ export default class WorkSpecifications extends Component {
                         FIELDS.WORK_SPECIFICATIONS.FOLLOW_UP_DESCRIPTION
                       ]
                     }
-                  ></textarea>
+                  />
                 </div>
               )}
               <div className="form-group">


### PR DESCRIPTION
Closes #189 

This PR addresses break tags contained in Knack API responses. The break tags were replaced with new line characters in the response strings to show the user the same text on-screen before and after submission of these fields.

### Before
![Screen Shot 2019-09-16 at 4 15 44 PM](https://user-images.githubusercontent.com/37249039/64996274-1bd93780-d8a3-11e9-8ff9-b5b8ffe036af.png)

### After
![Screen Shot 2019-09-16 at 4 39 49 PM](https://user-images.githubusercontent.com/37249039/64996277-1d0a6480-d8a3-11e9-9c2f-7da3abe8146b.png)
