### PR TITLE
Add high accuracy option to geolocation fn

### DIFF
--- a/src/components/WorkOrder/AssetTypeField.js
+++ b/src/components/WorkOrder/AssetTypeField.js
@@ -81,18 +81,25 @@ export default class AssetTypeField extends Component {
   componentDidMount() {
     this.setState({ loading: true });
     let userPosition = {};
-    navigator.geolocation.getCurrentPosition(pos => {
-      userPosition["lat"] = pos.coords.latitude;
-      userPosition["lon"] = pos.coords.longitude;
+    const geolocateOptions = {
+      enableHighAccuracy: true,
+    };
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        userPosition["lat"] = pos.coords.latitude;
+        userPosition["lon"] = pos.coords.longitude;
 
-      getSignalsOptions(userPosition).then(data => {
-        this.setState({
-          signalOptions: data,
-          loading: false,
-          userPosition: userPosition,
+        getSignalsOptions(userPosition).then(data => {
+          this.setState({
+            signalOptions: data,
+            loading: false,
+            userPosition: userPosition,
+          });
         });
-      });
-    });
+      },
+      () => console.log("Geolocation error"),
+      geolocateOptions
+    );
   }
 
   handleAutocompleteChange = (assetTypeString, e) => {


### PR DESCRIPTION
Added enableHighAccuracy option to Geolocation.getCurrentPosition() to test improving the Nearby Signals feature in the New Work Order form.