### PR TITLE
Edit and QC Detectors Links in Search Signals view

### DIFF
--- a/src/components/Assets/AssetTable.js
+++ b/src/components/Assets/AssetTable.js
@@ -6,7 +6,7 @@ import {
   addDetectionLinks,
 } from "./helpers";
 
-const AssetTable = ({ fields, data, assetId, title, workOrderId }) => {
+const AssetTable = ({ fields, data, assetId, title }) => {
   const tableHeaders = fields.map(field =>
     formatDataTitles(Object.keys(field))
   );
@@ -18,9 +18,7 @@ const AssetTable = ({ fields, data, assetId, title, workOrderId }) => {
   // TODO handle URLs returned from Knack - make URLs set state to change current asset?
   return (
     <div className="table-responsive">
-      {workOrderId &&
-        title === "Detection" &&
-        addDetectionLinks(assetId, workOrderId)}
+      {title === "Detection" && addDetectionLinks(assetId)}
       <table className="table">
         <thead>
           <tr>

--- a/src/components/Assets/Assets.js
+++ b/src/components/Assets/Assets.js
@@ -150,37 +150,36 @@ class Assets extends Component {
           <FontAwesomeIcon icon={faMapMarkerAlt} /> {this.state.pageHeading}
         </h1>
 
-        {this.state.assetOptions.length > 0 &&
-          this.state.viewedAsset === "" && (
-            <form>
-              <div className="form-group">
-                <br />
-                <Autocomplete
-                  getItemValue={item => item.id}
-                  items={this.state.assetOptions}
-                  inputProps={this.inputProps("asset")}
-                  wrapperStyle={this.wrapperStyle}
-                  menuStyle={this.menuStyle}
-                  renderItem={(item, isHighlighted) =>
-                    this.renderItem(item, isHighlighted)
-                  }
-                  shouldItemRender={(item, value) =>
-                    this.shouldItemRender(item, value)
-                  }
-                  value={this.state.typedAsset}
-                  onChange={this.handleAutocompleteChange}
-                  onSelect={(value, item) => this.onAssetSelect(value, item)}
-                />
-                <button
-                  type="button"
-                  className="btn btn-danger ml-2 btn-lg"
-                  onClick={this.clearAssetSearch}
-                >
-                  Clear
-                </button>
-              </div>
-            </form>
-          )}
+        {this.state.assetOptions.length > 0 && this.state.viewedAsset === "" && (
+          <form>
+            <div className="form-group">
+              <br />
+              <Autocomplete
+                getItemValue={item => item.id}
+                items={this.state.assetOptions}
+                inputProps={this.inputProps("asset")}
+                wrapperStyle={this.wrapperStyle}
+                menuStyle={this.menuStyle}
+                renderItem={(item, isHighlighted) =>
+                  this.renderItem(item, isHighlighted)
+                }
+                shouldItemRender={(item, value) =>
+                  this.shouldItemRender(item, value)
+                }
+                value={this.state.typedAsset}
+                onChange={this.handleAutocompleteChange}
+                onSelect={(value, item) => this.onAssetSelect(value, item)}
+              />
+              <button
+                type="button"
+                className="btn btn-danger ml-2 btn-lg"
+                onClick={this.clearAssetSearch}
+              >
+                Clear
+              </button>
+            </div>
+          </form>
+        )}
 
         {this.state.loading && (
           <FontAwesomeIcon icon={faSpinner} size="2x" className="atd-spinner" />
@@ -231,7 +230,6 @@ class Assets extends Component {
                         data={this.state[stateName]}
                         fields={table[tableKey]}
                         assetId={this.state.assetDetailsData.id}
-                        workOrderId={this.props.match.params.workOrderId}
                         title={title}
                       />
                     </AccordionItemBody>

--- a/src/components/Assets/helpers.js
+++ b/src/components/Assets/helpers.js
@@ -67,13 +67,12 @@ export const createDetectorLink = (id, assetId) => (
   </div>
 );
 
-export const addDetectionLinks = (assetId, workOrderId) => (
+export const addDetectionLinks = assetId => (
   <div>
     <a
       class="btn btn-primary btn-lg mb-2 mr-2"
       role="button"
-      // href={`https://transportation.austintexas.io/data-tracker/#work-orders/work-order-details/${workOrderId}/signal-details/${assetId}/edit-signal-detectors/${assetId}/`}
-      href={`https://transportation.austintexas.io/data-tracker/#home/signals/signal-details/${assetId}/edit-signal-detectors/${assetId}/
+      href={`https://transportation.austintexas.io/data-tracker/#home/signals/signal-details/${assetId}/edit-signal-detectors/${assetId}/`}
     >
       <FontAwesomeIcon icon={faEdit} /> {"Edit Detectors"}
     </a>

--- a/src/components/Assets/helpers.js
+++ b/src/components/Assets/helpers.js
@@ -72,7 +72,8 @@ export const addDetectionLinks = (assetId, workOrderId) => (
     <a
       class="btn btn-primary btn-lg mb-2 mr-2"
       role="button"
-      href={`https://transportation.austintexas.io/data-tracker/#work-orders/work-order-details/${workOrderId}/signal-details/${assetId}/edit-signal-detectors/${assetId}/`}
+      // href={`https://transportation.austintexas.io/data-tracker/#work-orders/work-order-details/${workOrderId}/signal-details/${assetId}/edit-signal-detectors/${assetId}/`}
+      href={`https://transportation.austintexas.io/data-tracker/#home/signals/signal-details/${assetId}/edit-signal-detectors/${assetId}/
     >
       <FontAwesomeIcon icon={faEdit} /> {"Edit Detectors"}
     </a>


### PR DESCRIPTION
Closes #188 

This PR adds the Edit Detectors and Detectors QC links to the Signals Details view found through the Signals Search feature. The link to the Edit Detectors view was changed to a route that only requires the signal ID (instead of using a link that depended on having a work order ID). This change allowed removing logic that differentiated between retrieving the record through a work order `/work-orders/:workOrderId/assets/:assetId` or searching for it `/assets`.