### PR TITLE
Fix broken logout button

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -86,7 +86,7 @@ class App extends Component {
   };
 
   revokeKnackUserToken = () => {
-    this.setState({ knackUserToken: false });
+    this.setState({ knackUserToken: false, isLoggedIn: false });
     Cookies.set("knackUserToken", false);
   };
 
@@ -111,7 +111,6 @@ class App extends Component {
     const knackUserTokenExpiration = Cookies.get("knackUserTokenExpiration");
     const knackUserToken = Cookies.get("knackUserToken");
     // if knackUserToken exists and is unexpired, user is logged in
-    console.log(knackUserTokenExpiration, knackUserToken);
     return (
       !!knackUserToken &&
       !!knackUserTokenExpiration &&


### PR DESCRIPTION
This PR fixes a bug where the logout button set the user's knack token cookie to false but did not update `isLoggedIn` state to `false` in the App component. Redirect to the login screen depends on this state in the App component (see snippet).https://github.com/cityofaustin/atd-mobile-signals-work-orders/blob/e582df85463bc6c63ac0063e464f820cddce45e7/src/components/App.js#L150

 Prior to this change, the `knackUserToken` cookie would set to false and then no redirect would happen. The logout button now redirects to the login screen once again.