### PR TITLE
New Work Order view breaks when refreshing the page

### DIFF
--- a/src/components/WorkOrder/WorkTypeFields.js
+++ b/src/components/WorkOrder/WorkTypeFields.js
@@ -1,7 +1,11 @@
 import React, { Component } from "react";
 import Select from "react-select";
 
-import { WORK_TYPE_TROUBLE_CALL_OPTIONS, FIELDS } from "./formConfig";
+import {
+  WORK_TYPE_TROUBLE_CALL_OPTIONS,
+  WORK_TYPE_SCHEDULED_WORK_OPTIONS,
+  FIELDS,
+} from "./formConfig";
 import { getWorkTypeScheduledWorkOptions } from "../../queries/knackObjectHelpers";
 
 export default class WorkTypeFields extends Component {
@@ -11,7 +15,7 @@ export default class WorkTypeFields extends Component {
     this.state = {
       data: props.data,
       workTypeScheduledWorkOptions: getWorkTypeScheduledWorkOptions(
-        window.Knack
+        WORK_TYPE_SCHEDULED_WORK_OPTIONS
       ),
       updatedFormData: {},
     };
@@ -36,7 +40,7 @@ export default class WorkTypeFields extends Component {
     this.setState({
       updatedFormData: data,
       workTypeScheduledWorkOptions: getWorkTypeScheduledWorkOptions(
-        window.Knack
+        WORK_TYPE_SCHEDULED_WORK_OPTIONS
       ),
     });
 

--- a/src/queries/knackObjectHelpers.js
+++ b/src/queries/knackObjectHelpers.js
@@ -1,15 +1,5 @@
-export const getWorkTypeScheduledWorkOptions = knack => {
-  if (knack === null || knack.objects === undefined) {
-    return [];
-  } else {
-    return knack.objects.models
-      .find(model => model.attributes.name === "work_orders_signals")
-      .attributes.fields.find(
-        field => field.name === "WORK_TYPE_SCHEDULED_WORK"
-      )
-      .format.options.map(option => ({
-        label: option,
-        value: option,
-      }));
-  }
-};
+export const getWorkTypeScheduledWorkOptions = options =>
+  options.map(option => ({
+    label: option,
+    value: option,
+  }));


### PR DESCRIPTION
Closes #232 

This PR addresses a bug encountered when trying to access options for Scheduled Work Type in the New Work Order form from the `Knack` object. I changed the source to be an existing array in `formConfig.js`. I tested this by making a new work order (with and without multiple scheduled work types) and also editing a work order.