### PR TITLE
Redirect to work order view upon successfully adding a new inventory item or edit existing item

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,7 +23,6 @@ import NewWorkOrder from "./WorkOrder/New";
 import EditWorkOrder from "./WorkOrder/Edit";
 import SubmitWorkOrder from "./WorkOrder/Submit";
 import NewTimeLog from "./WorkOrder/NewTimeLog";
-import InventoryItems from "./WorkOrder/InventoryItems";
 import AddImage from "./WorkOrder/AddImage";
 import Assets from "./Assets/Assets";
 import { APP_ID } from "../constants/api";
@@ -200,11 +199,6 @@ class App extends Component {
                 component={NewTimeLog}
                 knackObject={this.state.knackObject}
                 isEditable={true}
-              />
-              <Route
-                path="/work-order/inventory-items/:workOrderId"
-                component={InventoryItems}
-                knackObject={this.state.knackObject}
               />
               <Route
                 path="/work-order/add-image/:workOrderId"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -207,11 +207,6 @@ class App extends Component {
                 knackObject={this.state.knackObject}
               />
               <Route
-                path="/work-order/:workOrderId/edit-inventory-item/:inventoryItemId"
-                component={InventoryItems}
-                knackObject={this.state.knackObject}
-              />
-              <Route
                 path="/work-order/add-image/:workOrderId"
                 component={AddImage}
                 knackObject={this.state.knackObject}

--- a/src/components/Form/SubmitButton.js
+++ b/src/components/Form/SubmitButton.js
@@ -9,7 +9,7 @@ export default class SubmitButton extends Component {
         type="submit"
         className={
           this.props.style ||
-          `btn btn-primary btn-lg ${
+          `btn btn-primary btn-lg ${this.props.buttonStyles} ${
             this.props.isFormDisabled ? "disabled" : ""
           }`
         }

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -56,7 +56,7 @@ class InventoryItemTable extends Component {
     return (
       <>
         <div
-          className={`btn btn-success btn-lg`}
+          className={`btn btn-success btn-lg mb-3`}
           onClick={this.handleAddInventoryItemClick}
         >
           <FontAwesomeIcon icon={faWrench} /> Add Item
@@ -164,9 +164,9 @@ class InventoryItemTable extends Component {
                       />
                     ) : (
                       <>
-                        <div className="col-6">
+                        <div className="col-6 ">
                           <div
-                            className={`btn btn-success btn-lg`}
+                            className={`btn btn-success btn-lg btn-block`}
                             onClick={e =>
                               this.handleConfirmCancelItemClick(e, inventory.id)
                             }
@@ -174,9 +174,9 @@ class InventoryItemTable extends Component {
                             <FontAwesomeIcon icon={faCheck} /> Yes
                           </div>
                         </div>
-                        <div className="col-6">
+                        <div className="col-6 ">
                           <div
-                            className={`btn btn-danger btn-lg`}
+                            className={`btn btn-danger btn-lg btn-block`}
                             onClick={() =>
                               this.setState({ itemSelectedforCancel: "" })
                             }

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { WorkOrderInventoryStatus } from "../../styles/WorkOrderInventoryStatus";
 import { workOrderFields } from "../../queries/fields";
 import api from "../../queries/api";
-import Button from "../Form/Button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faWrench,

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -164,7 +164,7 @@ class InventoryItemTable extends Component {
                       />
                     ) : (
                       <>
-                        <div className="col-6 ">
+                        <div className="col-6">
                           <div
                             className={`btn btn-success btn-lg btn-block`}
                             onClick={e =>
@@ -174,7 +174,7 @@ class InventoryItemTable extends Component {
                             <FontAwesomeIcon icon={faCheck} /> Yes
                           </div>
                         </div>
-                        <div className="col-6 ">
+                        <div className="col-6">
                           <div
                             className={`btn btn-danger btn-lg btn-block`}
                             onClick={() =>

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -42,7 +42,7 @@ class InventoryItemTable extends Component {
   };
 
   handleEditInventoryItemClick = (e, itemId) => {
-    // Fire callback fn from WorkOrderDetails to set itemId edit
+    // Set itemId of edit and switch isEditingInventoryItem to show edit form
     this.props.handleEditInventoryItem(itemId);
   };
 

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -52,7 +52,7 @@ class InventoryItemTable extends Component {
   };
 
   render() {
-    const { inventoryData, workOrderId } = this.props;
+    const { inventoryData } = this.props;
     return (
       <>
         <div

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -41,6 +41,11 @@ class InventoryItemTable extends Component {
       });
   };
 
+  handleEditInventoryItemClick = (e, itemId) => {
+    // Fire callback fn from WorkOrderDetails to set itemId edit
+    this.props.handleEditInventoryItem(itemId);
+  };
+
   render() {
     const { inventoryData, workOrderId } = this.props;
     return (
@@ -76,14 +81,14 @@ class InventoryItemTable extends Component {
                         />
                       </div>
                       <div className="col pt-2">
-                        <Button
-                          icon={faEdit}
-                          text={"Edit"}
-                          linkPath={`/work-order/${workOrderId}/edit-inventory-item/${
-                            inventory.id
-                          }`}
-                          color={"primary"}
-                        />
+                        <div
+                          className={`btn btn-primary btn-lg`}
+                          onClick={e =>
+                            this.handleEditInventoryItemClick(e, inventory.id)
+                          }
+                        >
+                          <FontAwesomeIcon icon={faEdit} /> Edit
+                        </div>
                       </div>
                       <div className="col pt-2">
                         {/* Only show cancel button if status is not "Issued" and cancelled is false */}

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -41,6 +41,11 @@ class InventoryItemTable extends Component {
       });
   };
 
+  handleAddInventoryItemClick = e => {
+    // Switch isAddingInventoryItem to show add form
+    this.props.handleAddInventoryItem();
+  };
+
   handleEditInventoryItemClick = (e, itemId) => {
     // Set itemId of edit and switch isEditingInventoryItem to show edit form
     this.props.handleEditInventoryItem(itemId);
@@ -50,11 +55,12 @@ class InventoryItemTable extends Component {
     const { inventoryData, workOrderId } = this.props;
     return (
       <>
-        <Button
-          icon={faWrench}
-          text={"New Item"}
-          linkPath={`/work-order/inventory-items/${workOrderId}`}
-        />
+        <div
+          className={`btn btn-success btn-lg`}
+          onClick={this.handleAddInventoryItemClick}
+        >
+          <FontAwesomeIcon icon={faWrench} /> Add Item
+        </div>
         {inventoryData.length === 0 && <p>No data</p>}
         {inventoryData.length > 0 && (
           <ul className="list-group list-group-flush">

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -20,7 +20,7 @@ class InventoryItems extends Component {
     };
   }
   componentDidMount() {
-    // Render edit form if inventoryItemId exists
+    // Render edit form if editing item
     this.props.isEditing && this.setState({ isEditable: true });
   }
 

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -63,7 +63,7 @@ class InventoryItems extends Component {
 
     inventorySubmitRequest()
       .then(res => {
-        // If editing, clear itemSelectedforEdit and switch isEditingInventoryItem to restore table view
+        // If editing, clear itemSelectedforEdit, switch isEditingInventoryItem to restore table view, and refetch inventory
         this.state.isEditable && this.props.completeInventoryItemEdit();
 
         this.setState({ isSubmitting: false, isSubmitted: true });

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -69,12 +69,10 @@ class InventoryItems extends Component {
       .then(res => {
         // Clear itemSelectedforEdit, switch view state in parent to restore table view, and refetch inventory
         this.props.restoreInventoryTable();
-
         this.setState({ isSubmitting: false, isSubmitted: true });
       })
       .catch(error => {
         console.log(error.response.data.errors);
-
         this.setState({
           errors: error.response.data.errors,
           isSubmitting: false,
@@ -119,20 +117,14 @@ class InventoryItems extends Component {
             />
           )}
           <div className="row">
-            <div
-              className="col-6
-            "
-            >
+            <div className="col-6">
               <SubmitButton
                 text={`${this.renderInventoryFormVerb()} Item`}
                 buttonStyles={`btn-block`}
                 isSubmitting={this.state.isSubmitting}
               />
             </div>
-            <div
-              className="col-6
-            "
-            >
+            <div className="col-6">
               <div
                 className={`btn btn-danger btn-lg btn-block`}
                 onClick={this.handleFormCancel}

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -21,8 +21,7 @@ class InventoryItems extends Component {
   }
   componentDidMount() {
     // Render edit form if inventoryItemId exists
-    this.props.match.params.inventoryItemId &&
-      this.setState({ isEditable: true });
+    this.props.isEditing && this.setState({ isEditable: true });
   }
 
   handleInventoryItemChange = (fieldId, selected) => {
@@ -106,7 +105,7 @@ class InventoryItems extends Component {
             <EditInventoryItemsFields
               handleInventoryItemChange={this.handleInventoryItemChange}
               handleItemPropertyChange={this.handleItemPropertyChange}
-              inventoryItemId={this.props.match.params.inventoryItemId}
+              inventoryItemId={this.props.itemSelectedforEdit}
             />
           )}
           <SubmitButton

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -39,6 +39,10 @@ class InventoryItems extends Component {
     this.setState({ formData });
   };
 
+  handleFormCancel = () => {
+    this.props.restoreInventoryTable();
+  };
+
   renderInventoryFormVerb = () => (this.state.isEditable ? "Edit" : "Add");
 
   submitForm = e => {
@@ -103,6 +107,7 @@ class InventoryItems extends Component {
             <AddInventoryItemsFields
               handleInventoryItemChange={this.handleInventoryItemChange}
               handleItemPropertyChange={this.handleItemPropertyChange}
+              handleFormCancel={this.handleFormCancel}
             />
           )}
           {this.state.isEditable && (
@@ -110,12 +115,32 @@ class InventoryItems extends Component {
               handleInventoryItemChange={this.handleInventoryItemChange}
               handleItemPropertyChange={this.handleItemPropertyChange}
               inventoryItemId={this.props.itemSelectedforEdit}
+              handleFormCancel={this.handleFormCancel}
             />
           )}
-          <SubmitButton
-            text={`${this.renderInventoryFormVerb()} Item`}
-            isSubmitting={this.state.isSubmitting}
-          />
+          <div className="row">
+            <div
+              className="col-6
+            "
+            >
+              <SubmitButton
+                text={`${this.renderInventoryFormVerb()} Item`}
+                buttonStyles={`btn-block`}
+                isSubmitting={this.state.isSubmitting}
+              />
+            </div>
+            <div
+              className="col-6
+            "
+            >
+              <div
+                className={`btn btn-danger btn-lg btn-block`}
+                onClick={this.handleFormCancel}
+              >
+                Cancel
+              </div>
+            </div>
+          </div>
         </form>
       </div>
     );

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -63,8 +63,8 @@ class InventoryItems extends Component {
 
     inventorySubmitRequest()
       .then(res => {
-        // If editing, clear itemSelectedforEdit, switch isEditingInventoryItem to restore table view, and refetch inventory
-        this.state.isEditable && this.props.completeInventoryItemEdit();
+        // Clear itemSelectedforEdit, switch view state in parent to restore table view, and refetch inventory
+        this.props.restoreInventoryTable();
 
         this.setState({ isSubmitting: false, isSubmitted: true });
       })

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -45,12 +45,12 @@ class InventoryItems extends Component {
     e.preventDefault();
     const formData = {
       ...this.state.formData,
-      [FIELDS.WORK_ORDER_ID_FOR_INVENTORY]: this.props.match.params.workOrderId,
+      [FIELDS.WORK_ORDER_ID_FOR_INVENTORY]: this.props.workOrderId,
     };
     console.log(formData);
     this.setState({ isSubmitting: true });
 
-    const inventoryItemId = this.props.match.params.inventoryItemId;
+    const inventoryItemId = this.props.itemSelectedforEdit;
     // Define submit options
     const postRecord = () => api.workOrder().submitInventoryItem(formData);
     const putRecord = () =>
@@ -63,10 +63,14 @@ class InventoryItems extends Component {
 
     inventorySubmitRequest()
       .then(res => {
+        // If editing, clear itemSelectedforEdit and switch isEditingInventoryItem to restore table view
+        this.state.isEditable && this.props.completeInventoryItemEdit();
+
         this.setState({ isSubmitting: false, isSubmitted: true });
       })
       .catch(error => {
         console.log(error.response.data.errors);
+
         this.setState({
           errors: error.response.data.errors,
           isSubmitting: false,

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -50,6 +50,8 @@ class WorkOrderDetail extends Component {
       userInfo: "",
       isSubmitting: false,
       atdWorkOrderId: "",
+      isAddingInventoryItem: false,
+      isEditingInventoryItem: false,
     };
 
     // Split the Details fields in two so we can display them side by side and
@@ -197,6 +199,7 @@ class WorkOrderDetail extends Component {
   render() {
     const statusField = this.state.detailsData.field_459;
     const workOrderId = this.props.match.params.workOrderId;
+    const { isAddingInventoryItem, isEditingInventoryItem } = this.state;
     return (
       <div>
         <StyledPageTitle>
@@ -297,12 +300,15 @@ class WorkOrderDetail extends Component {
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              <InventoryItemTable
-                inventoryData={this.state.inventoryData}
-                atdWorkOrderId={this.state.atdWorkOrderId}
-                workOrderId={workOrderId}
-                requestInventory={this.requestInventory}
-              />
+              {!isAddingInventoryItem &&
+                !isEditingInventoryItem && (
+                  <InventoryItemTable
+                    inventoryData={this.state.inventoryData}
+                    atdWorkOrderId={this.state.atdWorkOrderId}
+                    workOrderId={workOrderId}
+                    requestInventory={this.requestInventory}
+                  />
+                )}
             </AccordionItemBody>
           </AccordionItem>
           <AccordionItem>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -183,11 +183,16 @@ class WorkOrderDetail extends Component {
   };
 
   completeInventoryItemEdit = () => {
-    debugger;
-    this.setState({
-      itemSelectedforEdit: "",
-      isEditingInventoryItem: false,
-    });
+    // Clear item selected, turn off isEditingInventoryItem to show inventory table, and then refetch inventory
+    this.setState(
+      {
+        itemSelectedforEdit: "",
+        isEditingInventoryItem: false,
+      },
+      () => {
+        this.requestInventory(this.state.atdWorkOrderId);
+      }
+    );
   };
 
   isWorkOrderAssignedToUserLoggedIn = () => {

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -175,6 +175,8 @@ class WorkOrderDetail extends Component {
       });
   };
 
+  handleAddInventoryItem = () => this.setState({ isAddingInventoryItem: true });
+
   handleEditInventoryItem = inventoryItemId => {
     this.setState({
       itemSelectedforEdit: inventoryItemId,
@@ -182,12 +184,13 @@ class WorkOrderDetail extends Component {
     });
   };
 
-  completeInventoryItemEdit = () => {
-    // Clear item selected, turn off isEditingInventoryItem to show inventory table, and then refetch inventory
+  restoreInventoryTable = () => {
+    // Clear item selected, turn off adding and editing, then refetch inventory
     this.setState(
       {
         itemSelectedforEdit: "",
         isEditingInventoryItem: false,
+        isAddingInventoryItem: false,
       },
       () => {
         this.requestInventory(this.state.atdWorkOrderId);
@@ -326,6 +329,7 @@ class WorkOrderDetail extends Component {
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
+              {/* If editing or adding item, render InventoryItems component with child forms for either case */}
               {!isAddingInventoryItem &&
                 !isEditingInventoryItem && (
                   <InventoryItemTable
@@ -333,18 +337,18 @@ class WorkOrderDetail extends Component {
                     atdWorkOrderId={this.state.atdWorkOrderId}
                     workOrderId={workOrderId}
                     requestInventory={this.requestInventory}
+                    handleAddInventoryItem={this.handleAddInventoryItem}
                     handleEditInventoryItem={this.handleEditInventoryItem}
                   />
                 )}
-              {isAddingInventoryItem ||
-                (isEditingInventoryItem && (
-                  <InventoryItems
-                    isEditing={isEditingInventoryItem}
-                    itemSelectedforEdit={itemSelectedforEdit}
-                    completeInventoryItemEdit={this.completeInventoryItemEdit}
-                    workOrderId={workOrderId}
-                  />
-                ))}
+              {(isAddingInventoryItem || isEditingInventoryItem) && (
+                <InventoryItems
+                  isEditing={isEditingInventoryItem}
+                  itemSelectedforEdit={itemSelectedforEdit}
+                  restoreInventoryTable={this.restoreInventoryTable}
+                  workOrderId={workOrderId}
+                />
+              )}
             </AccordionItemBody>
           </AccordionItem>
           <AccordionItem>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -36,6 +36,7 @@ import {
   getWorkOrderTitle,
   getWorkOrderDetailAndTimeLogs,
 } from "./WorkOrder/helpers";
+import InventoryItems from "./WorkOrder/InventoryItems";
 
 class WorkOrderDetail extends Component {
   _isMounted = false;
@@ -52,6 +53,7 @@ class WorkOrderDetail extends Component {
       atdWorkOrderId: "",
       isAddingInventoryItem: false,
       isEditingInventoryItem: false,
+      itemSelectedforEdit: "",
     };
 
     // Split the Details fields in two so we can display them side by side and
@@ -173,6 +175,13 @@ class WorkOrderDetail extends Component {
       });
   };
 
+  handleEditInventoryItem = inventoryItemId => {
+    this.setState({
+      itemSelectedforEdit: inventoryItemId,
+      isEditingInventoryItem: true,
+    });
+  };
+
   isWorkOrderAssignedToUserLoggedIn = () => {
     const userId = this.state.userInfo.id;
     const usersArray = this.state.detailsData.field_1754_raw;
@@ -199,7 +208,11 @@ class WorkOrderDetail extends Component {
   render() {
     const statusField = this.state.detailsData.field_459;
     const workOrderId = this.props.match.params.workOrderId;
-    const { isAddingInventoryItem, isEditingInventoryItem } = this.state;
+    const {
+      isAddingInventoryItem,
+      isEditingInventoryItem,
+      itemSelectedforEdit,
+    } = this.state;
     return (
       <div>
         <StyledPageTitle>
@@ -307,8 +320,16 @@ class WorkOrderDetail extends Component {
                     atdWorkOrderId={this.state.atdWorkOrderId}
                     workOrderId={workOrderId}
                     requestInventory={this.requestInventory}
+                    handleEditInventoryItem={this.handleEditInventoryItem}
                   />
                 )}
+              {isAddingInventoryItem ||
+                (isEditingInventoryItem && (
+                  <InventoryItems
+                    isEditing={isEditingInventoryItem}
+                    itemSelectedforEdit={itemSelectedforEdit}
+                  />
+                ))}
             </AccordionItemBody>
           </AccordionItem>
           <AccordionItem>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -182,6 +182,14 @@ class WorkOrderDetail extends Component {
     });
   };
 
+  completeInventoryItemEdit = () => {
+    debugger;
+    this.setState({
+      itemSelectedforEdit: "",
+      isEditingInventoryItem: false,
+    });
+  };
+
   isWorkOrderAssignedToUserLoggedIn = () => {
     const userId = this.state.userInfo.id;
     const usersArray = this.state.detailsData.field_1754_raw;
@@ -328,6 +336,8 @@ class WorkOrderDetail extends Component {
                   <InventoryItems
                     isEditing={isEditingInventoryItem}
                     itemSelectedforEdit={itemSelectedforEdit}
+                    completeInventoryItemEdit={this.completeInventoryItemEdit}
+                    workOrderId={workOrderId}
                   />
                 ))}
             </AccordionItemBody>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1230
Closes https://github.com/cityofaustin/atd-data-tech/issues/1231

This PR addresses the problem of users not being redirected to the Work Order Details view after adding or editing an inventory item. In order to solve this, I changed the views render to keep all inventory item transactions within the accordion on the Work Order Details view. The view that renders within the accordion tab is now controlled by state in the `WorkOrderDetails` component. After completing the add or edit form, the view rendered is switched back to the inventory table and data is refetched to update the records in the view.

This also address the issue with users not returning to the Work Order Details view with the same accordion open that was open when they initiated an item add or edit. Since all transactions are handled in the Work Orders view, the accordion never closes during view the table, adding items, or editing items.

I added cancel buttons to the "Add" and "Edit" forms so that the user isn't trapped in these views, and I also updated the "Cancel" confirmation "Yes" and "No" buttons to take half of the width of the view each.

### Add form in accordion
![Screen Shot 2020-01-27 at 2 18 11 PM](https://user-images.githubusercontent.com/37249039/73211070-24733180-4111-11ea-8e58-89cdcdf9b19a.png)

### Edit form in accordion
![Screen Shot 2020-01-27 at 2 19 08 PM](https://user-images.githubusercontent.com/37249039/73211089-2a691280-4111-11ea-8f2f-6686a32ae1f7.png)

### New cancel confirmation button widths
![Screen Shot 2020-01-27 at 1 50 42 PM](https://user-images.githubusercontent.com/37249039/73211104-2e953000-4111-11ea-8de7-d98678ceb940.png)

