### PR TITLE
Implement Post-Form Submission `atd-knack-api` Call for Inventory

### DIFF
--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -38,6 +38,7 @@ class InventoryItemTable extends Component {
       .then(() => {
         this.setState({ itemSelectedforCancel: "", isCancelling: false });
         this.props.requestInventory(this.props.atdWorkOrderId);
+        api.workOrder().atdKnackApiCallInventoryItem();
       });
   };
 

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -65,6 +65,7 @@ class InventoryItems extends Component {
     inventorySubmitRequest()
       .then(res => {
         this.setState({ isSubmitting: false, isSubmitted: true });
+        api.workOrder().atdKnackApiCallInventoryItem();
       })
       .catch(error => {
         console.log(error.response.data.errors);

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -371,6 +371,15 @@ const api = {
           data,
           getHeaders()
         ),
+      // Fires after any inventory item form submission
+      atdKnackApiCallInventoryItem: () => {
+        // Determine baseUrl based on environment
+        const stagingBaseUrl = `https://ywx4jkcwrh.execute-api.us-east-1.amazonaws.com/dev/inventory/`;
+        const prodBaseUrl = `https://knack-api.austinmobility.io/inventory/`;
+        axios.post(
+          `${isProd ? prodBaseUrl : stagingBaseUrl}?src=${``}&dest={``}`
+        );
+      },
       getImages: id =>
         axios.get(
           `https://api.knack.com/v1/scenes/${keys.addImage.sceneId}/views/${

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -376,7 +376,7 @@ const api = {
         // Determine url by environment => {base-url}?src={source-app-id}&dest={dest-app-id}
         const environmentConfig = {
           staging: {
-            baseUrl: `https://ywx4jkcwrh.execute-api.us-east-1.amazonaws.com/dev/inventory/`,
+            baseUrl: `https://knack-api-dev.austinmobility.io/inventory`,
             sourceId: STAGING_APP_ID,
             destinationId: `5b422c9b13774837e54ed814`,
           },

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -388,10 +388,9 @@ const api = {
         };
         const environment = isProd ? `production` : `staging`;
         axios.post(
-          `${environmentConfig[environment.baseUrl]}?src=${
-            environmentConfig[environment.sourceId]
-          }
-          &dest=${environmentConfig[environment.destinationId]}`
+          `${environmentConfig[environment.baseUrl]}` +
+            `?src=${environmentConfig[environment.sourceId]}` +
+            `&dest=${environmentConfig[environment.destinationId]}`
         );
       },
       getImages: id =>

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -378,7 +378,7 @@ const api = {
           staging: {
             baseUrl: `https://ywx4jkcwrh.execute-api.us-east-1.amazonaws.com/dev/inventory/`,
             sourceId: STAGING_APP_ID,
-            destinationId: ``,
+            destinationId: `5b422c9b13774837e54ed814`,
           },
           production: {
             baseUrl: `https://knack-api.austinmobility.io/inventory/`,

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -388,9 +388,9 @@ const api = {
         };
         const environment = isProd ? `production` : `staging`;
         axios.post(
-          `${environmentConfig[environment.baseUrl]}` +
-            `?src=${environmentConfig[environment.sourceId]}` +
-            `&dest=${environmentConfig[environment.destinationId]}`
+          `${environmentConfig[environment].baseUrl}` +
+            `?src=${environmentConfig[environment].sourceId}` +
+            `&dest=${environmentConfig[environment].destinationId}`
         );
       },
       getImages: id =>

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -373,11 +373,25 @@ const api = {
         ),
       // Fires after any inventory item form submission
       atdKnackApiCallInventoryItem: () => {
-        // Determine baseUrl based on environment
-        const stagingBaseUrl = `https://ywx4jkcwrh.execute-api.us-east-1.amazonaws.com/dev/inventory/`;
-        const prodBaseUrl = `https://knack-api.austinmobility.io/inventory/`;
+        // Determine url by environment => {base-url}?src={source-app-id}&dest={dest-app-id}
+        const environmentConfig = {
+          staging: {
+            baseUrl: `https://ywx4jkcwrh.execute-api.us-east-1.amazonaws.com/dev/inventory/`,
+            sourceId: STAGING_APP_ID,
+            destinationId: ``,
+          },
+          production: {
+            baseUrl: `https://knack-api.austinmobility.io/inventory/`,
+            sourceId: PRODUCTION_APP_ID,
+            destinationId: `5b422c9b13774837e54ed814`,
+          },
+        };
+        const environment = isProd ? `production` : `staging`;
         axios.post(
-          `${isProd ? prodBaseUrl : stagingBaseUrl}?src=${``}&dest={``}`
+          `${environmentConfig[environment.baseUrl]}?src=${
+            environmentConfig[environment.sourceId]
+          }
+          &dest=${environmentConfig[environment.destinationId]}`
         );
       },
       getImages: id =>


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1288

This PR adds a POST to the `atd-knack-api` after an inventory item is created, edited, or cancelled.

@johnclary has tested this, and it is good to go unless any IDs need to be updated.