### PR TITLE
Refactor edit/add forms to be inline on Work Orders page

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,7 +22,6 @@ import AllWorkOrders from "./AllWorkOrders";
 import NewWorkOrder from "./WorkOrder/New";
 import EditWorkOrder from "./WorkOrder/Edit";
 import SubmitWorkOrder from "./WorkOrder/Submit";
-import NewTimeLog from "./WorkOrder/NewTimeLog";
 import AddImage from "./WorkOrder/AddImage";
 import Assets from "./Assets/Assets";
 import { APP_ID } from "../constants/api";

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -189,18 +189,6 @@ class App extends Component {
                 knackObject={this.state.knackObject}
               />
               <Route
-                path="/work-order/new-time-log/:workOrderId"
-                component={NewTimeLog}
-                knackObject={this.state.knackObject}
-                isEditable={false}
-              />
-              <Route
-                path="/work-order/:workOrderId/edit-time-log/:timeLogId"
-                component={NewTimeLog}
-                knackObject={this.state.knackObject}
-                isEditable={true}
-              />
-              <Route
                 path="/work-order/add-image/:workOrderId"
                 component={AddImage}
                 knackObject={this.state.knackObject}

--- a/src/components/Shared/dateTimeFieldHelpers.js
+++ b/src/components/Shared/dateTimeFieldHelpers.js
@@ -104,7 +104,7 @@ export const getSelectedTime = (data, field) => {
     (isEmpty(data[field]) && field === FIELDS.TIMELOG.WORKSITE_ARRIVE);
 
   if (shouldReturnCurrentDate) return today; // default to current time for certain fields
-  if (isEmpty(data[field])) return null; // let value start as blank if there's no exisiting data
+  if (isEmpty(data[field])) return null; // let value start as blank if there's no existing data
 
   let date = data[field].date
     ? data[field].date
@@ -118,6 +118,7 @@ export const getSelectedTime = (data, field) => {
 };
 
 export const formatDateTimeForFormValidation = (data, field) => {
+  if (isEmpty(data[field])) return null; // let value start as blank if there's no existing data
   let date = data[field].date ? data[field].date : data[`${field}_raw`].date;
 
   let momentDate = data[field].hours

--- a/src/components/WorkOrder/EditTimeLogDateTimeFields.js
+++ b/src/components/WorkOrder/EditTimeLogDateTimeFields.js
@@ -114,12 +114,14 @@ const EditTimeLogDateTimeFields = ({
 
   return (
     <div>
-      <TimeLogForm
-        getFormSelection={getFormSelection}
-        handleFormChange={handleDateTimeFieldChange}
-        isFormDisabled={isFormDisabled}
-        data={data}
-      />
+      {timeLogToEdit && (
+        <TimeLogForm
+          getFormSelection={getFormSelection}
+          handleFormChange={handleDateTimeFieldChange}
+          isFormDisabled={isFormDisabled}
+          data={data}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/WorkOrder/InventoryItems.js
+++ b/src/components/WorkOrder/InventoryItems.js
@@ -117,7 +117,7 @@ class InventoryItems extends Component {
               handleFormCancel={this.handleFormCancel}
             />
           )}
-          <div className="row my-3">
+          <div className="row mt-3">
             <div className="col-6">
               <SubmitButton
                 text={`${this.renderInventoryFormVerb()} Item`}

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -173,9 +173,6 @@ class NewTimeLog extends Component {
     const timeLogToEdit = this.state.timeLogData.filter(
       record => record.id === this.props.timeLogSelectedForEdit
     )[0];
-    const data = this.state.timeLogData;
-    const id = this.props;
-    debugger;
     this.setState({ timeLogToEdit });
   };
 
@@ -219,7 +216,7 @@ class NewTimeLog extends Component {
       return <Redirect to={`/work-orders/${this.workOrderId}`} />;
     }
 
-    const timeLogToEdit = this.state.timeLogToEdit;
+    const { timeLogToEdit } = this.state;
 
     return this.state.isLoading ? (
       <FontAwesomeIcon icon={faSpinner} className="atd-spinner" size="2x" />
@@ -297,13 +294,13 @@ class NewTimeLog extends Component {
             />
           )}
           {this.props.isEditingTimeLog &&
-            this.props.timeLogSelectedForEdit && (
+            timeLogToEdit && (
               <EditTimeLogDateTimeFields
                 data={this.state.updatedFormData}
                 handleTimeChange={this.handleDateTimeFieldChange}
                 handleFormDisable={this.handleFormDisable}
                 isFormDisabled={this.state.isFormDisabled}
-                timeLogToEdit={this.props.timeLogSelectedForEdit}
+                timeLogToEdit={timeLogToEdit}
               />
             )}
           <SubmitButton

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import Select from "react-select";
-import { Redirect } from "react-router-dom";
 
 import Header from "../Shared/Header";
 import { ErrorMessage } from "./Alerts";
@@ -204,6 +203,7 @@ class NewTimeLog extends Component {
 
   render() {
     const { timeLogToEdit } = this.state;
+    const { isEditingTimeLog } = this.props;
 
     return this.state.isLoading ? (
       <FontAwesomeIcon icon={faSpinner} className="atd-spinner" size="2x" />
@@ -211,7 +211,7 @@ class NewTimeLog extends Component {
       <div>
         <Header
           icon={faClock}
-          title={`${this.props.isEditingTimeLog ? "Edit" : "New"} Time Log`}
+          title={`${isEditingTimeLog ? "Edit" : "New"} Time Log`}
         />
 
         {this.state.errors &&
@@ -266,7 +266,7 @@ class NewTimeLog extends Component {
               )}
             />
           </div>
-          {!this.props.isEditingTimeLog && (
+          {!isEditingTimeLog && (
             <NewTimeLogDateTimeFields
               data={this.state.updatedFormData}
               handleTimeChange={this.handleDateTimeFieldChange}
@@ -274,7 +274,7 @@ class NewTimeLog extends Component {
               isFormDisabled={this.state.isFormDisabled}
             />
           )}
-          {this.props.isEditingTimeLog &&
+          {isEditingTimeLog &&
             timeLogToEdit && (
               <EditTimeLogDateTimeFields
                 data={this.state.updatedFormData}
@@ -287,9 +287,7 @@ class NewTimeLog extends Component {
           <div className="row">
             <div className="col-6">
               <SubmitButton
-                text={`${
-                  this.props.isEditingTimeLog ? "Edit" : "Add"
-                } Log Entry`}
+                text={`${isEditingTimeLog ? "Edit" : "Add"} Time Log`}
                 buttonStyles={`btn-block`}
                 isSubmitting={this.state.isSubmitting}
                 isFormDisabled={this.state.isFormDisabled}

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -21,7 +21,6 @@ class NewTimeLog extends Component {
     super(props);
 
     this.workOrderId = this.props.workOrderId;
-    this.isEditingTimeLog = this.props.isEditingTimeLog;
 
     this.state = {
       technicianOptions: [],
@@ -40,7 +39,7 @@ class NewTimeLog extends Component {
 
     console.log("submitting: ", this.state.updatedFormData, this.workOrderId);
 
-    !this.isEditingTimeLog &&
+    !this.props.isEditingTimeLog &&
       api
         .workOrder()
         .newTimeLog(this.workOrderId, this.state.updatedFormData)
@@ -60,11 +59,11 @@ class NewTimeLog extends Component {
           });
         });
 
-    this.isEditingTimeLog &&
+    this.props.isEditingTimeLog &&
       api
         .workOrder()
         .editTimeLog(
-          this.props.match.params.timeLogId,
+          this.props.timeLogSelectedForEdit,
           this.state.updatedFormData
         )
         .then(res => {
@@ -172,8 +171,11 @@ class NewTimeLog extends Component {
 
   setTimeLogToEdit = () => {
     const timeLogToEdit = this.state.timeLogData.filter(
-      record => record.id === this.props.match.params.timeLogId
+      record => record.id === this.props.timeLogSelectedForEdit
     )[0];
+    const data = this.state.timeLogData;
+    const id = this.props;
+    debugger;
     this.setState({ timeLogToEdit });
   };
 
@@ -225,7 +227,7 @@ class NewTimeLog extends Component {
       <div>
         <Header
           icon={faClock}
-          title={`${this.isEditingTimeLog ? "Edit" : "New"} Time Log`}
+          title={`${this.props.isEditingTimeLog ? "Edit" : "New"} Time Log`}
         />
 
         {this.state.errors &&
@@ -286,7 +288,7 @@ class NewTimeLog extends Component {
               )}
             />
           </div>
-          {!this.isEditingTimeLog && (
+          {!this.props.isEditingTimeLog && (
             <NewTimeLogDateTimeFields
               data={this.state.updatedFormData}
               handleTimeChange={this.handleDateTimeFieldChange}
@@ -294,18 +296,18 @@ class NewTimeLog extends Component {
               isFormDisabled={this.state.isFormDisabled}
             />
           )}
-          {this.isEditingTimeLog &&
-            timeLogToEdit && (
+          {this.props.isEditingTimeLog &&
+            this.props.timeLogSelectedForEdit && (
               <EditTimeLogDateTimeFields
                 data={this.state.updatedFormData}
                 handleTimeChange={this.handleDateTimeFieldChange}
                 handleFormDisable={this.handleFormDisable}
                 isFormDisabled={this.state.isFormDisabled}
-                timeLogToEdit={timeLogToEdit}
+                timeLogToEdit={this.props.timeLogSelectedForEdit}
               />
             )}
           <SubmitButton
-            text={`${this.isEditingTimeLog ? "Edit" : "Add"} Log Entry`}
+            text={`${this.props.isEditingTimeLog ? "Edit" : "Add"} Log Entry`}
             isSubmitting={this.state.isSubmitting}
             isFormDisabled={this.state.isFormDisabled}
           />

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -176,6 +176,10 @@ class NewTimeLog extends Component {
     this.setState({ timeLogToEdit });
   };
 
+  handleFormCancelClick = () => {
+    this.props.handleTimeLogFormCancel();
+  };
+
   requestTimeLogs = id => {
     this.setState({ isLoading: true });
     api
@@ -303,11 +307,26 @@ class NewTimeLog extends Component {
                 timeLogToEdit={timeLogToEdit}
               />
             )}
-          <SubmitButton
-            text={`${this.props.isEditingTimeLog ? "Edit" : "Add"} Log Entry`}
-            isSubmitting={this.state.isSubmitting}
-            isFormDisabled={this.state.isFormDisabled}
-          />
+          <div className="row">
+            <div className="col-6">
+              <SubmitButton
+                text={`${
+                  this.props.isEditingTimeLog ? "Edit" : "Add"
+                } Log Entry`}
+                buttonStyles={`btn-block`}
+                isSubmitting={this.state.isSubmitting}
+                isFormDisabled={this.state.isFormDisabled}
+              />
+            </div>
+            <div className="col-6">
+              <div
+                className={`btn btn-danger btn-lg btn-block`}
+                onClick={this.handleFormCancelClick}
+              >
+                Cancel
+              </div>
+            </div>
+          </div>
         </form>
       </div>
     );

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -50,6 +50,7 @@ class NewTimeLog extends Component {
             isSubmitted: true,
             successfulResponseData: res.data.record,
           });
+          this.props.restoreTimeLogTable();
         })
         .catch(error => {
           console.log(error.response.data.errors);
@@ -72,6 +73,7 @@ class NewTimeLog extends Component {
             isSubmitted: true,
             successfulResponseData: res.data.record,
           });
+          this.props.restoreTimeLogTable();
         })
         .catch(error => {
           console.log(error.response.data.errors);

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -39,48 +39,36 @@ class NewTimeLog extends Component {
 
     console.log("submitting: ", this.state.updatedFormData, this.workOrderId);
 
-    !this.props.isEditingTimeLog &&
-      api
-        .workOrder()
-        .newTimeLog(this.workOrderId, this.state.updatedFormData)
-        .then(res => {
-          this.setState({
-            isSubmitting: false,
-            isSubmitted: true,
-            successfulResponseData: res.data.record,
-          });
-          this.props.restoreTimeLogTable();
-        })
-        .catch(error => {
-          console.log(error.response.data.errors);
-          this.setState({
-            errors: error.response.data.errors,
-            isSubmitting: false,
-          });
-        });
-
-    this.props.isEditingTimeLog &&
+    const postRecord = () =>
+      api.workOrder().newTimeLog(this.workOrderId, this.state.updatedFormData);
+    const putRecord = () =>
       api
         .workOrder()
         .editTimeLog(
           this.props.timeLogSelectedForEdit,
           this.state.updatedFormData
-        )
-        .then(res => {
-          this.setState({
-            isSubmitting: false,
-            isSubmitted: true,
-            successfulResponseData: res.data.record,
-          });
-          this.props.restoreTimeLogTable();
-        })
-        .catch(error => {
-          console.log(error.response.data.errors);
-          this.setState({
-            errors: error.response.data.errors,
-            isSubmitting: false,
-          });
+        );
+
+    const timeLogSubmitRequest = this.props.isEditingTimeLog
+      ? putRecord
+      : postRecord;
+
+    timeLogSubmitRequest()
+      .then(res => {
+        this.setState({
+          isSubmitting: false,
+          isSubmitted: true,
+          successfulResponseData: res.data.record,
         });
+        this.props.restoreTimeLogTable();
+      })
+      .catch(error => {
+        console.log(error.response.data.errors);
+        this.setState({
+          errors: error.response.data.errors,
+          isSubmitting: false,
+        });
+      });
   };
 
   handleChange = e => {
@@ -215,11 +203,6 @@ class NewTimeLog extends Component {
   }
 
   render() {
-    if (!!this.state.successfulResponseData) {
-      console.log(this.state.successfulResponseData);
-      return <Redirect to={`/work-orders/${this.workOrderId}`} />;
-    }
-
     const { timeLogToEdit } = this.state;
 
     return this.state.isLoading ? (
@@ -260,12 +243,6 @@ class NewTimeLog extends Component {
                 FIELDS.TIMELOG.TECHNICIANS
               )}
             />
-            {/* <small
-              className="form-text"
-              id={`${FIELDS.TIMELOG.TECHNICIANS}-text`}
-            >
-              Leave blank for yourself
-            </small> */}
           </div>
           <div className="form-group">
             <label htmlFor={FIELDS.TIMELOG.VEHICLES}>Vehicles(s)</label>

--- a/src/components/WorkOrder/NewTimeLog.js
+++ b/src/components/WorkOrder/NewTimeLog.js
@@ -20,8 +20,8 @@ class NewTimeLog extends Component {
   constructor(props) {
     super(props);
 
-    this.workOrderId = this.props.match.params.workOrderId;
-    this.isEditable = this.props.match.path.includes("edit");
+    this.workOrderId = this.props.workOrderId;
+    this.isEditingTimeLog = this.props.isEditingTimeLog;
 
     this.state = {
       technicianOptions: [],
@@ -40,7 +40,7 @@ class NewTimeLog extends Component {
 
     console.log("submitting: ", this.state.updatedFormData, this.workOrderId);
 
-    !this.isEditable &&
+    !this.isEditingTimeLog &&
       api
         .workOrder()
         .newTimeLog(this.workOrderId, this.state.updatedFormData)
@@ -59,7 +59,7 @@ class NewTimeLog extends Component {
           });
         });
 
-    this.isEditable &&
+    this.isEditingTimeLog &&
       api
         .workOrder()
         .editTimeLog(
@@ -223,7 +223,7 @@ class NewTimeLog extends Component {
       <div>
         <Header
           icon={faClock}
-          title={`${this.isEditable ? "Edit" : "New"} Time Log`}
+          title={`${this.isEditingTimeLog ? "Edit" : "New"} Time Log`}
         />
 
         {this.state.errors &&
@@ -284,7 +284,7 @@ class NewTimeLog extends Component {
               )}
             />
           </div>
-          {!this.isEditable && (
+          {!this.isEditingTimeLog && (
             <NewTimeLogDateTimeFields
               data={this.state.updatedFormData}
               handleTimeChange={this.handleDateTimeFieldChange}
@@ -292,7 +292,7 @@ class NewTimeLog extends Component {
               isFormDisabled={this.state.isFormDisabled}
             />
           )}
-          {this.isEditable &&
+          {this.isEditingTimeLog &&
             timeLogToEdit && (
               <EditTimeLogDateTimeFields
                 data={this.state.updatedFormData}
@@ -303,7 +303,7 @@ class NewTimeLog extends Component {
               />
             )}
           <SubmitButton
-            text={`${this.isEditable ? "Edit" : "Add"} Log Entry`}
+            text={`${this.isEditingTimeLog ? "Edit" : "Add"} Log Entry`}
             isSubmitting={this.state.isSubmitting}
             isFormDisabled={this.state.isFormDisabled}
           />

--- a/src/components/WorkOrder/TimeLog.js
+++ b/src/components/WorkOrder/TimeLog.js
@@ -1,12 +1,23 @@
 import React from "react";
 import Button from "../Form/Button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSpinner, faEdit } from "@fortawesome/free-solid-svg-icons";
+import { faSpinner, faEdit, faClock } from "@fortawesome/free-solid-svg-icons";
 import { FIELDS } from "./formConfig";
 
-const TimeLog = ({ data, workOrderId }) => {
+const TimeLog = ({ data, workOrderId, handleAddTimeLog }) => {
+  const handleAddTimeLogClick = e => {
+    // Switch isAddingInventoryItem to show add form
+    handleAddTimeLog();
+  };
+
   return (
     <div>
+      <div
+        className={`btn btn-success btn-lg mb-3`}
+        onClick={handleAddTimeLogClick}
+      >
+        <FontAwesomeIcon icon={faClock} /> Add Time Log
+      </div>
       {data.length === 0 && <p>No data</p>}
       {data.length > 0 && (
         <ul className="list-group list-group-flush">
@@ -69,7 +80,9 @@ const TimeLog = ({ data, workOrderId }) => {
                 <Button
                   icon={faEdit}
                   text={"Edit"}
-                  linkPath={`/work-order/${workOrderId}/edit-time-log/${timeLog.id}`}
+                  linkPath={`/work-order/${workOrderId}/edit-time-log/${
+                    timeLog.id
+                  }`}
                   color={"primary"}
                 />
               </div>

--- a/src/components/WorkOrder/TimeLog.js
+++ b/src/components/WorkOrder/TimeLog.js
@@ -1,5 +1,4 @@
 import React from "react";
-import Button from "../Form/Button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner, faEdit, faClock } from "@fortawesome/free-solid-svg-icons";
 import { FIELDS } from "./formConfig";
@@ -11,6 +10,7 @@ const TimeLog = ({ data, handleAddTimeLog, handleEditTimeLog }) => {
   };
 
   const handleEditTimeLogClick = (e, timeLogId) => {
+    // Switch isEditingInventoryItem to show edit form
     handleEditTimeLog(timeLogId);
   };
 

--- a/src/components/WorkOrder/TimeLog.js
+++ b/src/components/WorkOrder/TimeLog.js
@@ -4,10 +4,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner, faEdit, faClock } from "@fortawesome/free-solid-svg-icons";
 import { FIELDS } from "./formConfig";
 
-const TimeLog = ({ data, workOrderId, handleAddTimeLog }) => {
+const TimeLog = ({ data, handleAddTimeLog, handleEditTimeLog }) => {
   const handleAddTimeLogClick = e => {
     // Switch isAddingInventoryItem to show add form
     handleAddTimeLog();
+  };
+
+  const handleEditTimeLogClick = (e, timeLogId) => {
+    handleEditTimeLog(timeLogId);
   };
 
   return (
@@ -77,14 +81,12 @@ const TimeLog = ({ data, workOrderId, handleAddTimeLog }) => {
                 </div>
               </div>
               <div className="col-3 mt-2">
-                <Button
-                  icon={faEdit}
-                  text={"Edit"}
-                  linkPath={`/work-order/${workOrderId}/edit-time-log/${
-                    timeLog.id
-                  }`}
-                  color={"primary"}
-                />
+                <div
+                  className={`btn btn-primary btn-lg`}
+                  onClick={e => handleEditTimeLogClick(e, timeLog.id)}
+                >
+                  <FontAwesomeIcon icon={faEdit} /> Edit
+                </div>
               </div>
             </li>
           ))}

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -54,9 +54,10 @@ class WorkOrderDetail extends Component {
       atdWorkOrderId: "",
       isAddingInventoryItem: false,
       isEditingInventoryItem: false,
+      itemSelectedForEdit: "",
       isAddingTimeLog: false,
       isEditingTimeLog: false,
-      itemSelectedforEdit: "",
+      timeLogSelectedforEdit: null,
     };
 
     // Split the Details fields in two so we can display them side by side and
@@ -189,6 +190,13 @@ class WorkOrderDetail extends Component {
 
   handleAddTimeLog = () => this.setState({ isAddingTimeLog: true });
 
+  handleEditTimeLog = timeLogId => {
+    this.setState({
+      timeLogSelectedForEdit: timeLogId,
+      isEditingTimeLog: true,
+    });
+  };
+
   restoreTimeLogTable = () => {
     this.setState(
       {
@@ -247,6 +255,7 @@ class WorkOrderDetail extends Component {
       itemSelectedforEdit,
       isAddingTimeLog,
       isEditingTimeLog,
+      timeLogSelectedForEdit,
     } = this.state;
     return (
       <div>
@@ -321,14 +330,17 @@ class WorkOrderDetail extends Component {
                     data={this.state.timeLogData}
                     workOrderId={workOrderId}
                     handleAddTimeLog={this.handleAddTimeLog}
+                    handleEditTimeLog={this.handleEditTimeLog}
                   />
                 )}
-              {(isAddingTimeLog || isEditingTimeLog) && (
+              {(isAddingTimeLog ||
+                (isEditingTimeLog && timeLogSelectedForEdit)) && (
                 <NewTimeLog
                   workOrderId={workOrderId}
                   isAddingTimeLog={isAddingTimeLog}
                   isEditingTimeLog={isEditingTimeLog}
                   restoreTimeLogTable={this.restoreTimeLogTable}
+                  timeLogSelectedForEdit={timeLogSelectedForEdit}
                 />
               )}
             </AccordionItemBody>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -159,7 +159,7 @@ class WorkOrderDetail extends Component {
     this.state.detailsData["field_977"] === "Signal" && (
       <Link
         to={`/work-orders/${
-          this.props.match.params.workOrderId
+          this.workOrderId
         }/assets/${this.getAssetIdFromKnackLink()}`}
       >
         <FontAwesomeIcon icon={faMapMarkedAlt} /> {"View Signal Details"}
@@ -168,7 +168,7 @@ class WorkOrderDetail extends Component {
 
   handleReopenClick = e => {
     e.preventDefault();
-    const workOrderId = this.props.match.params.workOrderId;
+    const workOrderId = this.workOrderId;
     // To reopen work order, Knack wants payload with ID
     this.setState({ isSubmitting: true });
     api
@@ -256,7 +256,7 @@ class WorkOrderDetail extends Component {
 
   render() {
     const statusField = this.state.detailsData.field_459;
-    const workOrderId = this.props.match.params.workOrderId;
+    const workOrderId = this.workOrderId;
     const {
       isAddingInventoryItem,
       isEditingInventoryItem,

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -210,6 +210,13 @@ class WorkOrderDetail extends Component {
     );
   };
 
+  handleTimeLogFormCancel = () => {
+    this.setState({
+      isEditingTimeLog: false,
+      isAddingTimeLog: false,
+    });
+  };
+
   restoreInventoryTable = () => {
     // Clear item selected, turn off adding and editing, then refetch inventory
     this.setState(
@@ -341,6 +348,7 @@ class WorkOrderDetail extends Component {
                   isAddingTimeLog={isAddingTimeLog}
                   isEditingTimeLog={isEditingTimeLog}
                   restoreTimeLogTable={this.restoreTimeLogTable}
+                  handleTimeLogFormCancel={this.handleTimeLogFormCancel}
                   timeLogSelectedForEdit={timeLogSelectedForEdit}
                 />
               )}

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -189,6 +189,18 @@ class WorkOrderDetail extends Component {
 
   handleAddTimeLog = () => this.setState({ isAddingTimeLog: true });
 
+  restoreTimeLogTable = () => {
+    this.setState(
+      {
+        isEditingTimeLog: false,
+        isAddingTimeLog: false,
+      },
+      () => {
+        this.requestTimeLogs(this.state.atdWorkOrderId);
+      }
+    );
+  };
+
   restoreInventoryTable = () => {
     // Clear item selected, turn off adding and editing, then refetch inventory
     this.setState(
@@ -316,6 +328,7 @@ class WorkOrderDetail extends Component {
                   workOrderId={workOrderId}
                   isAddingTimeLog={isAddingTimeLog}
                   isEditingTimeLog={isEditingTimeLog}
+                  restoreTimeLogTable={this.restoreTimeLogTable}
                 />
               )}
             </AccordionItemBody>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -28,6 +28,7 @@ import {
 import "react-accessible-accordion/dist/fancy-example.css";
 
 import TimeLog from "./WorkOrder/TimeLog";
+import NewTimeLog from "./WorkOrder/NewTimeLog";
 import WorkSpecifications from "./WorkOrder/WorkSpecifications";
 import UploadImage from "./WorkOrder/UploadImage";
 import api from "../queries/api";
@@ -53,6 +54,8 @@ class WorkOrderDetail extends Component {
       atdWorkOrderId: "",
       isAddingInventoryItem: false,
       isEditingInventoryItem: false,
+      isAddingTimeLog: false,
+      isEditingTimeLog: false,
       itemSelectedforEdit: "",
     };
 
@@ -184,6 +187,8 @@ class WorkOrderDetail extends Component {
     });
   };
 
+  handleAddTimeLog = () => this.setState({ isAddingTimeLog: true });
+
   restoreInventoryTable = () => {
     // Clear item selected, turn off adding and editing, then refetch inventory
     this.setState(
@@ -228,6 +233,8 @@ class WorkOrderDetail extends Component {
       isAddingInventoryItem,
       isEditingInventoryItem,
       itemSelectedforEdit,
+      isAddingTimeLog,
+      isEditingTimeLog,
     } = this.state;
     return (
       <div>
@@ -296,15 +303,21 @@ class WorkOrderDetail extends Component {
               </h3>
             </AccordionItemTitle>
             <AccordionItemBody>
-              <Button
-                icon={faClock}
-                text={"New Time Log"}
-                linkPath={`/work-order/new-time-log/${workOrderId}`}
-              />
-              <TimeLog
-                data={this.state.timeLogData}
-                workOrderId={workOrderId}
-              />
+              {!isAddingTimeLog &&
+                !isEditingTimeLog && (
+                  <TimeLog
+                    data={this.state.timeLogData}
+                    workOrderId={workOrderId}
+                    handleAddTimeLog={this.handleAddTimeLog}
+                  />
+                )}
+              {(isAddingTimeLog || isEditingTimeLog) && (
+                <NewTimeLog
+                  workOrderId={workOrderId}
+                  isAddingTimeLog={isAddingTimeLog}
+                  isEditingTimeLog={isEditingTimeLog}
+                />
+              )}
             </AccordionItemBody>
           </AccordionItem>
           <AccordionItem>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -65,6 +65,7 @@ class WorkOrderDetail extends Component {
     this.halfDetails = Math.ceil(workOrderFields.details.length / 2);
     this.detailsFirstHalf = workOrderFields.details.slice(0, this.halfDetails);
     this.detailsSecondHalf = workOrderFields.details.slice(this.halfDetails);
+    this.workOrderId = this.props.match.params.workOrderId;
   }
 
   renderDetailItem(field) {
@@ -88,11 +89,11 @@ class WorkOrderDetail extends Component {
     window.analytics.page("Work Order Details");
 
     this._isMounted = true;
-    const { workOrderId } = this.props.match.params;
-    getWorkOrderTitle(workOrderId).then(data => {
+
+    getWorkOrderTitle(this.workOrderId).then(data => {
       this._isMounted && this.setState({ titleData: data });
     });
-    getWorkOrderDetailAndTimeLogs(workOrderId).then(data => {
+    getWorkOrderDetailAndTimeLogs(this.workOrderId).then(data => {
       this._isMounted && this.setState({ detailsData: data });
 
       // Need to retrieve ATD Work Order ID from details in order to req associated inv. items
@@ -108,8 +109,8 @@ class WorkOrderDetail extends Component {
         this._isMounted && this.setState({ userInfo: res.data });
       });
     // Stagger the calls to Knack API so we don't get rate limited.
-    setTimeout(this.requestTimeLogs, 500, workOrderId);
-    setTimeout(this.requestImages, 1000, workOrderId);
+    setTimeout(this.requestTimeLogs, 500, this.workOrderId);
+    setTimeout(this.requestImages, 1000, this.workOrderId);
   }
 
   componentWillUnmount() {
@@ -204,7 +205,7 @@ class WorkOrderDetail extends Component {
         isAddingTimeLog: false,
       },
       () => {
-        this.requestTimeLogs(this.state.atdWorkOrderId);
+        this.requestTimeLogs(this.workOrderId);
       }
     );
   };


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1303

This PR refactors the Add/Edit Time Log feature in the Work Order Details view to live inside the accordion. I removed the routes for adding/editing time logs, and I replaced the references to url parameters (for record IDs) with props. I also added "cancel" buttons to the add/edit forms to allow the user to navigate back to the Time Log table in the accordion without having to submit the form or refresh. Time log data is also refetched after adds/edits.

I fixed one bug that appeared where the Edit Form would break when updating fields. Just needed to mirror the `getSelectedTime()` handler used in the New Time Log form and handle empty fields in `formatDateTimeForFormValidation()` since all fields in a time log are not always filled in.

### New Time Log form
![image](https://user-images.githubusercontent.com/37249039/74177319-205e0e00-4bff-11ea-94a8-09233bcae567.png)

### Edit Time Log form
![image](https://user-images.githubusercontent.com/37249039/74177329-248a2b80-4bff-11ea-8f64-62c938674fab.png)
