### PR TITLE
Display supporting tech within Work Order Details

### DIFF
--- a/src/components/Form/SubmitButton.js
+++ b/src/components/Form/SubmitButton.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 

--- a/src/components/WorkOrder/InventoryItemTable.js
+++ b/src/components/WorkOrder/InventoryItemTable.js
@@ -10,7 +10,6 @@ import {
   faEdit,
   faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
-import Button from "../Form/Button";
 
 class InventoryItemTable extends Component {
   constructor(props) {

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -66,15 +66,8 @@ class WorkOrderDetail extends Component {
   renderDetailItem(field) {
     const key = Object.values(field)[0];
     const label = Object.keys(field)[0];
-    // if (key === "field_909") {
-    //   debugger;
-    // }
-
     const value = this.state.detailsData[Object.values(field)[0]];
-    // console.log(value);
-    // if (!!value) {
-    //   debugger;
-    // }
+
     const detailText =
       value === undefined || typeof value === "string"
         ? value

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -68,17 +68,12 @@ class WorkOrderDetail extends Component {
     const label = Object.keys(field)[0];
     const value = this.state.detailsData[Object.values(field)[0]];
 
-    const detailText =
-      value === undefined || typeof value === "string"
-        ? value
-        : value.map(value => value.identifier).join(", ");
-
     return (
       <dl key={key}>
         <dt>{label}</dt>
         <dd
           dangerouslySetInnerHTML={{
-            __html: detailText,
+            __html: value,
           }}
         />
       </dl>

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -66,14 +66,26 @@ class WorkOrderDetail extends Component {
   renderDetailItem(field) {
     const key = Object.values(field)[0];
     const label = Object.keys(field)[0];
+    // if (key === "field_909") {
+    //   debugger;
+    // }
+
     const value = this.state.detailsData[Object.values(field)[0]];
+    // console.log(value);
+    // if (!!value) {
+    //   debugger;
+    // }
+    const detailText =
+      value === undefined || typeof value === "string"
+        ? value
+        : value.map(value => value.identifier).join(", ");
 
     return (
       <dl key={key}>
         <dt>{label}</dt>
         <dd
           dangerouslySetInnerHTML={{
-            __html: value,
+            __html: detailText,
           }}
         />
       </dl>
@@ -90,7 +102,6 @@ class WorkOrderDetail extends Component {
     });
     getWorkOrderDetailAndTimeLogs(workOrderId).then(data => {
       this._isMounted && this.setState({ detailsData: data });
-
       // Need to retrieve ATD Work Order ID from details in order to req associated inv. items
       const atdWorkOrderId = data.field_1209;
       // Save atdWorkOrderId for refetching data after inventory updates

--- a/src/queries/fields.js
+++ b/src/queries/fields.js
@@ -20,6 +20,7 @@ export const workOrderFields = {
     { "Reported By": "field_968" },
     { "Technicians Logged": "field_1753" },
     { "Vehicles Logged": "field_1427" },
+    { "Support Tech(s)": "field_909_raw" },
   ],
   header: "field_904",
   id: "id",

--- a/src/queries/fields.js
+++ b/src/queries/fields.js
@@ -10,7 +10,7 @@ export const workOrderFields = {
   details: [
     { "Problem Reported": "field_976" },
     { "Lead Technician": "field_1754" },
-    { "Support Tech(s)": "field_909_raw" },
+    { "Support Technician(s)": "field_909" },
     { "Asset Type": "field_977" },
     { "Created By": "field_458" },
     { "Created Date": "field_849" },

--- a/src/queries/fields.js
+++ b/src/queries/fields.js
@@ -10,6 +10,7 @@ export const workOrderFields = {
   details: [
     { "Problem Reported": "field_976" },
     { "Lead Technician": "field_1754" },
+    { "Support Tech(s)": "field_909_raw" },
     { "Asset Type": "field_977" },
     { "Created By": "field_458" },
     { "Created Date": "field_849" },
@@ -20,7 +21,6 @@ export const workOrderFields = {
     { "Reported By": "field_968" },
     { "Technicians Logged": "field_1753" },
     { "Vehicles Logged": "field_1427" },
-    { "Support Tech(s)": "field_909_raw" },
   ],
   header: "field_904",
   id: "id",


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1402

This PR adds the support technician(s) field ~and extends `renderDetailItem()` in the `WorkOrderDetails` component to handle fields that return arrays of records from Knack~ (realized the existing code renders the HTML returned from the Knack API).

Test record with multiple support technicians: http://localhost:3000/work-orders/5e22233605c56c085d50d384
Test record with one support technician: http://localhost:3000/work-orders/5e22220305c56c085d506801/

### New field in Work Order Details
![image](https://user-images.githubusercontent.com/37249039/74483003-2e1fc780-4e7b-11ea-8ccc-f9f325548668.png)
