### PR TITLE
Rename page titles to make them shorter

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -163,8 +163,9 @@ class App extends Component {
                 )}
               />
               <div className="container">
-                {pages.map(page => (
+                {pages.map((page, i) => (
                   <Route
+                    key={i}
                     render={props => <page.component {...props} />}
                     path={page.path}
                     exact={page.exact}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,7 +8,6 @@ import StyledHeader from "../styles/Header.css.js";
 const Header = ({ location, history, revokeKnackUserToken, pages }) => {
   const isNotHomePath = location.pathname !== "/";
   let currentPage = pages.find(page => page.path === location.pathname);
-  console.log(location.pathname, currentPage);
   // If there wasn't an exact match between the location.pathname & the imported
   // pages listing...
   if (!currentPage) {
@@ -16,7 +15,6 @@ const Header = ({ location, history, revokeKnackUserToken, pages }) => {
     if (location.pathname.includes("/work-order/edit")) {
       currentPage = pages.find(page => page.pageTitle === "Edit Work Order");
     } else if (location.pathname.includes("/assets")) {
-      // Work Order Details needs to go last since many of our paths include "/work-order"
       currentPage = pages.find(page => page.pageTitle === "Assets");
     } else if (location.pathname.includes("/work-orders")) {
       // Work Order Details needs to go last since many of our paths include "/work-order"

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -15,12 +15,11 @@ const Header = ({ location, history, revokeKnackUserToken, pages }) => {
     // match by page title string
     if (location.pathname.includes("/work-order/edit")) {
       currentPage = pages.find(page => page.pageTitle === "Edit Work Order");
-    } else if (location.pathname.includes("/new-time-log")) {
-      currentPage = pages.find(page => page.pageTitle === "New Time Log");
-    } else if (location.pathname.includes("/edit-time-log")) {
-      currentPage = pages.find(page => page.pageTitle === "Edit Time Log");
+    } else if (location.pathname.includes("/assets")) {
+      // Work Order Details needs to go last since many of our paths include "/work-order"
+      currentPage = pages.find(page => page.pageTitle === "Assets");
     } else if (location.pathname.includes("/work-orders")) {
-      // Work Order Details needs to go last since may of our paths include "/work-order"
+      // Work Order Details needs to go last since many of our paths include "/work-order"
       currentPage = pages.find(page => page.pageTitle === "Work Order Details");
     }
   }
@@ -42,7 +41,10 @@ const Header = ({ location, history, revokeKnackUserToken, pages }) => {
           </div>
           <div className="col text-center align-items-center justify-content-center d-flex">
             <h1 className="h2 mb-0">
-              <FontAwesomeIcon icon={currentPage ? currentPage.icon : ""} />{" "}
+              {currentPage &&
+                currentPage.icon && (
+                  <FontAwesomeIcon icon={currentPage.icon} />
+                )}{" "}
               {currentPage ? currentPage.pageTitle : ""}
             </h1>
           </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,7 +8,7 @@ import StyledHeader from "../styles/Header.css.js";
 const Header = ({ location, history, revokeKnackUserToken, pages }) => {
   const isNotHomePath = location.pathname !== "/";
   let currentPage = pages.find(page => page.path === location.pathname);
-
+  console.log(location.pathname, currentPage);
   // If there wasn't an exact match between the location.pathname & the imported
   // pages listing...
   if (!currentPage) {

--- a/src/components/MyWorkOrders.js
+++ b/src/components/MyWorkOrders.js
@@ -42,7 +42,7 @@ class MyWorkOrders extends Component {
       <div>
         <div className="d-flex flex-row">
           <div className="mr-2 mb-2">
-            <Link to={`/work-order/new/`}>
+            <Link to={`/work-order/new`}>
               <div className="btn btn-secondary btn-lg">
                 <FontAwesomeIcon icon={faWrench} /> New Work Order
               </div>

--- a/src/constants/pages.js
+++ b/src/constants/pages.js
@@ -5,7 +5,6 @@ import AllWorkOrders from "../components/AllWorkOrders";
 import NewWorkOrder from "../components/WorkOrder/New";
 import EditWorkOrder from "../components/WorkOrder/Edit";
 import SubmitWorkOrder from "../components/WorkOrder/Submit";
-import NewTimeLog from "../components/WorkOrder/NewTimeLog";
 import AddImage from "../components/WorkOrder/AddImage";
 import Assets from "../components/Assets/Assets";
 
@@ -16,7 +15,6 @@ import {
   faPlus,
   faMapMarkerAlt,
   faEdit,
-  faClock,
   faWrench,
 } from "@fortawesome/free-solid-svg-icons";
 
@@ -32,7 +30,7 @@ const pages = [
     path: "/my-work-orders",
     component: MyWorkOrders,
     mainPage: true,
-    pageTitle: "My Work Orders",
+    pageTitle: "Work Orders",
     icon: faStreetView,
   },
   {
@@ -40,13 +38,13 @@ const pages = [
     component: AllWorkOrders,
     mainPage: true,
     icon: faTruck,
-    pageTitle: "All Work Orders",
+    pageTitle: "Work Orders",
   },
   {
     path: "/work-order/new",
     component: NewWorkOrder,
     mainPage: true,
-    pageTitle: "New Work Order",
+    pageTitle: "Work Order",
     icon: faPlus,
   },
   {
@@ -82,7 +80,7 @@ const pages = [
     exact: true,
     component: Assets,
     mainPage: true,
-    pageTitle: "Search Signals",
+    pageTitle: "Signals",
     icon: faMapMarkerAlt,
   },
 ];


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/1229

This PR shortens the page titles described in the issue. I also fixed a couple of console warnings and a link to "New Work Order" that mismatched its route which made the title not render correctly.