### PR TITLE
Work Order Details "Submit" button is disabled when status is "In Progress"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,9 +4,9 @@
 
 # Staging and feature branches uses Test DB
 [context.master]
-    environment = { REACT_APP_KNACK_APP_ID = "5d52fcde610a550010c37502"}
+    environment = { REACT_APP_KNACK_APP_ID = "5e2216f0cbf8d9001616b034"}
 [context.branch-deploy]
-    environment = { REACT_APP_KNACK_APP_ID = "5d52fcde610a550010c37502"}
+    environment = { REACT_APP_KNACK_APP_ID = "5e2216f0cbf8d9001616b034"}
 
 [[headers]]
     for = "/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "my-app",
-  "version": "0.1.0",
+  "name": "atd-mobile-signals-work-orders",
+  "version": "0.7.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/AllWorkOrders.js
+++ b/src/components/AllWorkOrders.js
@@ -51,7 +51,7 @@ class AllWorkOrders extends Component {
           data={this.state.allWorkOrdersData}
           lastPage={this.state.lastPage}
           searchQuery={searchAllWorkOrders}
-          titleFieldId={fields.locationAll}
+          titleFieldId={fields.location}
         />
       </div>
     );

--- a/src/components/Assets/AssetMap.js
+++ b/src/components/Assets/AssetMap.js
@@ -14,11 +14,18 @@ const AssetMap = props => {
         parseFloat(locationData.longitude, 5),
       ]
     : null;
+
+  // See https://github.com/mariusandra/pigeon-maps/blob/4bb3d4ddf78cf1152da8c6462667e393b2b81790/demo/demo.js#L20
+  const provider = (x, y, z) => {
+    const s = String.fromCharCode(97 + ((x + y + z) % 3));
+    return `https://${s}.tile.openstreetmap.org/${z}/${x}/${y}.png`;
+  };
+
   return (
     <div className="container">
       <h3>{data[name]}</h3>
       {locationData && (
-        <Map center={coordinates} zoom={16} height={400}>
+        <Map center={coordinates} zoom={16} height={400} provider={provider}>
           <Marker anchor={coordinates} />
         </Map>
       )}

--- a/src/components/WorkOrder/New.js
+++ b/src/components/WorkOrder/New.js
@@ -150,24 +150,25 @@ class NewWorkOrder extends Component {
   submitForm = e => {
     e.preventDefault();
     this.setState({ errors: [], isSubmitting: true });
-    api
-      .workOrder()
-      .new(this.state.updatedFormData)
-      .then(res => {
-        this.setState({
-          isSubmitting: false,
-          isSubmitted: true,
-          newWorkOrder: res.data.record,
+    !this.state.isSubmitting &&
+      api
+        .workOrder()
+        .new(this.state.updatedFormData)
+        .then(res => {
+          this.setState({
+            isSubmitting: false,
+            isSubmitted: true,
+            newWorkOrder: res.data.record,
+          });
+        })
+        .catch(error => {
+          console.log(error.response.data.errors);
+          window.scrollTo(0, 0); // Scroll to top to see error msgs
+          this.setState({
+            errors: error.response.data.errors,
+            isSubmitting: false,
+          });
         });
-      })
-      .catch(error => {
-        console.log(error.response.data.errors);
-        window.scrollTo(0, 0); // Scroll to top to see error msgs
-        this.setState({
-          errors: error.response.data.errors,
-          isSubmitting: false,
-        });
-      });
   };
 
   componentDidMount() {

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -186,6 +186,15 @@ class WorkOrderDetail extends Component {
       </div>
     );
 
+  isWorkOrderComplete = statusField => {
+    // A complete work order has at least one time log, a status of either "Assigned" or "In Progress", and is not already submitted
+    return (
+      this.state.timeLogData.length > 0 &&
+      statusField !== "Submitted" &&
+      statusField === "Assigned"
+    );
+  };
+
   render() {
     const statusField = this.state.detailsData.field_459;
     const workOrderId = this.props.match.params.workOrderId;
@@ -210,9 +219,7 @@ class WorkOrderDetail extends Component {
                 }`}
               />
             )}
-          {this.state.timeLogData.length > 0 &&
-          statusField !== "Submitted" &&
-          statusField === "Assigned" ? (
+          {this.isWorkOrderComplete(statusField) ? (
             <Button
               icon={faFlagCheckered}
               text={"Submit"}

--- a/src/components/WorkOrderDetails.js
+++ b/src/components/WorkOrderDetails.js
@@ -191,7 +191,7 @@ class WorkOrderDetail extends Component {
     return (
       this.state.timeLogData.length > 0 &&
       statusField !== "Submitted" &&
-      statusField === "Assigned"
+      (statusField === "Assigned" || statusField === "In Progress")
     );
   };
 

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,3 +1,3 @@
-export const STAGING_APP_ID = "5e2216f0cbf8d9001616b034"; // 13-aug-2019--test-austin-transportation-data-tracker
+export const STAGING_APP_ID = "5e2216f0cbf8d9001616b034";
 export const PRODUCTION_APP_ID = "5815f29f7f7252cc2ca91c4f"; // amd
 export const APP_ID = process.env.REACT_APP_KNACK_APP_ID || STAGING_APP_ID;

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -1,3 +1,3 @@
-export const STAGING_APP_ID = "5d52fcde610a550010c37502"; // 13-aug-2019--test-austin-transportation-data-tracker
+export const STAGING_APP_ID = "5e2216f0cbf8d9001616b034"; // 13-aug-2019--test-austin-transportation-data-tracker
 export const PRODUCTION_APP_ID = "5815f29f7f7252cc2ca91c4f"; // amd
 export const APP_ID = process.env.REACT_APP_KNACK_APP_ID || STAGING_APP_ID;

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -77,7 +77,7 @@ const keys = {
   },
   workOrderDetails: { sceneId: "scene_297", viewId: "view_961" },
   workOrderImages: { sceneId: "scene_255", viewId: "view_2234" },
-  workOrderInventory: { sceneId: "scene_297", viewId: "view_885" },
+  workOrderInventory: { sceneId: "scene_514", viewId: "view_2673" },
   workOrderTimeLogs: { sceneId: "scene_297", viewId: "view_1251" },
   workOrderTitle: { sceneId: "scene_297", viewId: "view_910" },
   workOrderInventoryItems: {

--- a/src/queries/api.js
+++ b/src/queries/api.js
@@ -77,7 +77,7 @@ const keys = {
   },
   workOrderDetails: { sceneId: "scene_297", viewId: "view_961" },
   workOrderImages: { sceneId: "scene_255", viewId: "view_2234" },
-  workOrderInventory: { sceneId: "scene_514", viewId: "view_2673" },
+  workOrderInventory: { sceneId: "scene_297", viewId: "view_885" },
   workOrderTimeLogs: { sceneId: "scene_297", viewId: "view_1251" },
   workOrderTitle: { sceneId: "scene_297", viewId: "view_910" },
   workOrderInventoryItems: {

--- a/src/queries/fields.js
+++ b/src/queries/fields.js
@@ -5,7 +5,6 @@ export const workOrderFields = {
     modified: "field_1074",
     status: "field_459",
     location: "field_904",
-    locationAll: "field_211_raw",
     leadTechnicianRaw: "field_1754_raw",
   },
   details: [
@@ -22,7 +21,7 @@ export const workOrderFields = {
     { "Technicians Logged": "field_1753" },
     { "Vehicles Logged": "field_1427" },
   ],
-  header: "field_211_raw",
+  header: "field_904",
   id: "id",
   assetIdFromDetails: "field_199",
   inventory: {


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2626
Closes https://github.com/cityofaustin/atd-data-tech/issues/1587

**Note: The scene and view for the Inventory section in the Work Order Details view will not work locally in this branch since they have been updated in the staging Knack app for new features in `master`. The scene and view in this branch match those currently in production.**

Updates not already in `master`:
This PR updates the logic that determines if a work order is complete and allows work orders with "In Progress" status to be submitted. I also updated the tile source for `pigeon-maps` to OSM since I was reminded that the original tiles were being rate-limited while I tested this branch.

Updates already in `master`:
I fixed the Work Order Details location field for the title that was not populating. I also updated the staging app ID in the app and Netlify config.

#### Updated Work Order Details location title and enable submit button with status "In Progress"
<img width="659" alt="Screen Shot 2020-05-21 at 10 53 42 AM" src="https://user-images.githubusercontent.com/37249039/82578119-97396a00-9b51-11ea-9641-79d97f2a608a.png"> 

#### Original tile source
<img width="1494" alt="Screen Shot 2020-05-20 at 10 02 19 AM" src="https://user-images.githubusercontent.com/37249039/82577626-ddda9480-9b50-11ea-8d7b-1e38b9e317ae.png">

#### Updated tile source
<img width="1466" alt="Screen Shot 2020-05-20 at 2 54 33 PM" src="https://user-images.githubusercontent.com/37249039/82577709-f9de3600-9b50-11ea-984b-29ee37d4f235.png">



