### PR TITLE
App creates duplicate work orders in some cases

### DIFF
--- a/src/components/WorkOrder/New.js
+++ b/src/components/WorkOrder/New.js
@@ -150,24 +150,25 @@ class NewWorkOrder extends Component {
   submitForm = e => {
     e.preventDefault();
     this.setState({ errors: [], isSubmitting: true });
-    api
-      .workOrder()
-      .new(this.state.updatedFormData)
-      .then(res => {
-        this.setState({
-          isSubmitting: false,
-          isSubmitted: true,
-          newWorkOrder: res.data.record,
+    !this.state.isSubmitting &&
+      api
+        .workOrder()
+        .new(this.state.updatedFormData)
+        .then(res => {
+          this.setState({
+            isSubmitting: false,
+            isSubmitted: true,
+            newWorkOrder: res.data.record,
+          });
+        })
+        .catch(error => {
+          console.log(error.response.data.errors);
+          window.scrollTo(0, 0); // Scroll to top to see error msgs
+          this.setState({
+            errors: error.response.data.errors,
+            isSubmitting: false,
+          });
         });
-      })
-      .catch(error => {
-        console.log(error.response.data.errors);
-        window.scrollTo(0, 0); // Scroll to top to see error msgs
-        this.setState({
-          errors: error.response.data.errors,
-          isSubmitting: false,
-        });
-      });
   };
 
   componentDidMount() {


### PR DESCRIPTION
Closes https://github.com/cityofaustin/atd-data-tech/issues/2653

This PR updates the logic for firing a POST request to Knack from the New Work Order form. Previously, tapping the submit button more than once would send duplicate requests in the app.

